### PR TITLE
Fix check_inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,12 @@ build
 .tox
 __pycache__
 coverage.xml
+# remainings of tox tests
+/colvar*
+/bck*
+/plinp*
+/testmarkdown*
+/mermaid*
+# virtual environments
+/venv*
+/env*

--- a/check_inputs/create_inputs.py
+++ b/check_inputs/create_inputs.py
@@ -37,8 +37,9 @@ print('<h1 class="project-name">PLUMED</h1>')
 print('<h2 class="project-tagline">The community-developed PLUgin for MolEcular Dynamics</h2>')
 print('</section>')
 print('<section class="main-content">', flush=True)
-
-f = open("../tdata/tests.json")
+# Putting this here You can see render the page while it is being generated
+print( PlumedToHTML.get_html_header() )
+f = open("./tdata/tests.json")
 tests = json.load(f)
 f.close()
 

--- a/check_inputs/create_inputs.py
+++ b/check_inputs/create_inputs.py
@@ -49,7 +49,6 @@ for item in tests["regtests"] :
     print("Input number " + str(item["index"]))
     print( out )
 
-print( PlumedToHTML.get_html_header() )
 print('</section>')
 print('</body>')
 print('</html>')

--- a/check_inputs/create_inputs.py
+++ b/check_inputs/create_inputs.py
@@ -46,7 +46,12 @@ f.close()
 for item in tests["regtests"] :
     actions = set({})
     out = PlumedToHTML.test_and_get_html( item["input"], "plinp" + str(item["index"]), actions=actions )
-    print("Input number " + str(item["index"]))
+    
+    print(f"<h3>Input number {item['index']}</h3>")
+    #this visualizes the "from-to" and it is more clear to eye-check what is going on
+    print("<pre>")
+    print(item["input"])
+    print("</pre>")
     print( out )
 
 print('</section>')

--- a/check_inputs/make_inputs.sh
+++ b/check_inputs/make_inputs.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
+PlumedToHTMLInstalled=no
+# This script will test PlumedToHTML (without needing to install it)
 
-# Delete all the crap from the last time we ran this
-for file in `ls .` ; do
-    if [ $file != "make_inputs.sh" ] && [ $file != "create_inputs.py" ] ; then 
-       rm -rf $file
-    fi
-done
-
-# Create symbolic links to PlumedToHMTL
-ln -s ../PlumedToHTML/PlumedFormatter.py .
-ln -s ../PlumedToHTML/PlumedToHTML.py .
-ln -s ../PlumedToHTML/PlumedLexer.py
-ln -s ../PlumedtoHTML/assets .
-ln -s ../tdata .
-
+# Clean the previous run
+rm -rf testDir
+mkdir testDir
+cd testDir || {
+    echo "error in creating the testDirectory"
+    exit 1
+}
+if [[ $PlumedToHTMLInstalled = no ]]; then
+    # Create symbolic links to PlumedToHMTL
+    ln -s ../../PlumedToHTML/PlumedFormatter.py .
+    ln -s ../../PlumedToHTML/PlumedToHTML.py .
+    ln -s ../../PlumedToHTML/PlumedLexer.py .
+    ln -s ../../PlumedToHTML/assets .
+fi
+ln -s ../../tdata .
+cp ../create_inputs.py .
 # And run the python
-python create_inputs.py > check_site.html
+python create_inputs.py >check_site.html

--- a/check_inputs/make_inputs.sh
+++ b/check_inputs/make_inputs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-PlumedToHTMLInstalled=no
+# if PlumedToHTMLInstalled is not exported, assume it is not installed
+PlumedToHTMLInstalled=${PlumedToHTMLInstalled:-no}
 # This script will test PlumedToHTML (without needing to install it)
 
 # Clean the previous run
@@ -10,7 +11,7 @@ cd testDir || {
     exit 1
 }
 if [[ $PlumedToHTMLInstalled = no ]]; then
-    # Create symbolic links to PlumedToHMTL
+    # Create symbolic links to PlumedToHTML
     ln -s ../../PlumedToHTML/PlumedFormatter.py .
     ln -s ../../PlumedToHTML/PlumedToHTML.py .
     ln -s ../../PlumedToHTML/PlumedLexer.py .
@@ -18,5 +19,5 @@ if [[ $PlumedToHTMLInstalled = no ]]; then
 fi
 ln -s ../../tdata .
 cp ../create_inputs.py .
-# And run the python
+# And run the python script
 python create_inputs.py >check_site.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+lxml
+pygments
+requests
+bs4


### PR DESCRIPTION
I corrected some small typos in `make_inputs.sh` and I simplified it, by making everything happen in a subdirectory easier to eliminate

And added requirements.txt to make it possible to run it locally with no need to install

I also updated the `.gitignore` because I tried to use `tox`

I noted that if I install with `pip install .` or simply `pip install PLUMED` the asset folder is lacking, and so `PlumedToHTML.get_html_header()` crashes badly
I am setting up a PR to correct that