### PR TITLE
Now the assets are correcly installed along with the package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,21 @@ name: CI
 on: [push, pull_request]
 
 jobs: 
+  build-wheel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Show what is in the wheel (for debugging)
+      run: |
+        pip install build
+        python -m build .
+        unzip -l dist/PlumedToHTML*.whl
+
   build:
     runs-on: ubuntu-latest
 

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,6 @@ setuptools.setup(
      install_requires=['lxml','pygments','requests','bs4'],
      test_suite='nose.collector',
      tests_require=['nose'],
+     # This adds the assets that PlumedToHTML.get_html_header() asks for
+     include_package_data=True,
  )


### PR DESCRIPTION
If you download the tar or the wheel from here: https://pypi.org/project/PlumedToHTML/0.99/#files, you will get the package without the `asset` directory

The `asset/header.html` file there is used by `PlumedToHTML.get_html_header()` and since is not packed is a guaranteed error.

With this PR that error is solved

With `pip install .` I get the `check_inputs` directory installed in the environment, but with `python -m build .` the created wheel contains only PlumedToHTML with the assets :)

So I think this is a good improvement