### PR TITLE
Solving the huge border in badges in the new manual

### DIFF
--- a/src/PlumedToHTML/assets/header.html
+++ b/src/PlumedToHTML/assets/header.html
@@ -6,18 +6,18 @@
       "info badges";
     grid-template-columns: 90% 10%;
 }
-.plumedpreheader img{
-    max-width: 100%;
-    display: inline-block;
-    padding: 0px;
-    margin: 0px;
-}
 .plumedpreheader > div.headerInfo{
     grid-area: info;
 }
 .plumedpreheader > div.containerBadge{
     grid-area: badges;
     display: block;
+}
+.containerBadge img{
+    max-width: 100%;
+    display: inline-block;
+    padding: 0px;
+    margin: 0px;
 }
 pre.plumedlisting{
     width:97%;

--- a/src/PlumedToHTML/assets/header.html
+++ b/src/PlumedToHTML/assets/header.html
@@ -6,9 +6,14 @@
       "info badges";
     grid-template-columns: 90% 10%;
 }
+.plumedpreheader img{
+    max-width: 100%;
+    display: inline-block;
+    padding: 0px;
+    margin: 0px;
+}
 .plumedpreheader > div.headerInfo{
     grid-area: info;
-
 }
 .plumedpreheader > div.containerBadge{
     grid-area: badges;


### PR DESCRIPTION
These changes turn this
![image](https://github.com/user-attachments/assets/0d4b5f5a-452e-4636-8f0d-2ed012220339)

into this
![image](https://github.com/user-attachments/assets/f2c2f5ea-069f-4b43-ab76-d768b0508c4f)
in the manual.

These changes apply to any images that happen to be in a div with class `containerBadge`. 