### PR TITLE
Adding an  extra container to localize the horizontal scroll to the input file

### DIFF
--- a/src/PlumedToHTML/PlumedToHTML.py
+++ b/src/PlumedToHTML/PlumedToHTML.py
@@ -358,7 +358,8 @@ def get_html( inpt, name, outloc, tested, broken, plumedexe, usejson=None, maxch
     plumed_formatter = load_formatter_from_file(formatfile, "PlumedFormatter", keyword_dict=keyword_dict, input_name=name, hasload=found_load, broken=any(broken), auxinputs=inputfiles, auxinputlines=inputfilelines, valuedict=valuedict, actions=actions, checkaction=checkaction )
 
     # Now generate html of input
-    html = '<div class="plumedpreheader">\n'
+    html = '<div class="plumedInputContainer">\n'
+    html += '<div class="plumedpreheader">\n'
     html += f'<div class="headerInfo" id="value_details_{name}"> Click on the labels of the actions for more information on what each action computes </div>\n'
     html += '<div class="containerBadge">\n'
     for i in range(len(tested)) :
@@ -404,7 +405,8 @@ def get_html( inpt, name, outloc, tested, broken, plumedexe, usejson=None, maxch
     else : 
        # html += highlight( final_inpt, plumed_lexer, HtmlFormatter() )
        html += highlight( final_inpt, plumed_lexer, plumed_formatter )
-
+    #close the html = '<div class="plumedInputContainer">\n'
+    html += '</div>\n'
     # Now remove keywords that appear in examples
     mykeywords = plumed_formatter.getCheckActionKeywords()
     for key in mykeywords : 

--- a/src/PlumedToHTML/assets/header.html
+++ b/src/PlumedToHTML/assets/header.html
@@ -1,4 +1,8 @@
 <style>
+.plumedInputContainer{
+  width: 100%;
+  overflow: auto;
+}
 .plumedpreheader{
     width: 100%;
     display: grid;


### PR DESCRIPTION
Hi @gtribello 

Hopefully this should help in having a better visualization for the problem we are talking in https://github.com/plumed/plumed2/issues/1273. It is a workaround rather than a solution, because the text still exits the `<pre>` borders, but at least the scrollbar now is localized to the box with the "Click on the labels of the actions for more information on what each action computes " and the plumed input
The tootips are cut on the upper edge of the "Click on the labels of the actions for more information on what each action computes" text and on the lower part of the input file because of how the overflow kw works, the lower cut might be a lesser problem, since it looks like the pre element carves some extra space under it.

If you do not want to use the extra div in any sub-project I think you can simply override its css rule and hopefully it will behave as it is not there