### PR TITLE
Adding a formatter/check like astyle/codecheck

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,29 @@ name: CI
 on: [push, pull_request]
 
 jobs: 
+  check-code:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+        check: ["linting", "check-format"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: pyproject.toml
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+    - name: Check ${{ matrix.check }}
+      run: python -m tox -e ${{ matrix.check }}
   #this is setting up a new "test workflow" following the one we use for the plumed-testcenter
   setup-plumed:
     runs-on: ubuntu-latest
@@ -117,7 +140,6 @@ jobs:
         python -m pip install tox
     - name: Run tests
       run: |
-        #as now we do not want to be insulted by ruff, so only tests:
         python -m tox -e tests
 
     - name: Upload Coverage to Codecov

--- a/check_inputs/create_inputs.py
+++ b/check_inputs/create_inputs.py
@@ -1,85 +1,113 @@
-from pygments.styles import get_style_by_name
 from pygments.formatters import HtmlFormatter
-import os
 import json
 import PlumedToHTML
 
 # Output css file for codehighlighting
 ofile = open("codehilite.css", "w+")
-ofile.write( HtmlFormatter(cssclass="codehilite", style='colorful').get_style_defs() )
+ofile.write(HtmlFormatter(cssclass="codehilite", style="colorful").get_style_defs())
 ofile.close()
 
 print("<html>")
 print('<meta charset="utf-8">')
 print('<link rel="stylesheet" type="text/css" href="./codehilite.css">')
 print('<meta name="viewport" content="width=device-width">')
-print('<title>Example tutorial</title>')
+print("<title>Example tutorial</title>")
 print('<meta name="description" content="PLUMED website"/>')
 print('<meta name="viewport" content="width=device-width, initial-scale=1">')
 print('<meta name="theme-color" content="#157878">')
-print('<link href=\'https://fonts.googleapis.com/css?family=Open+Sans:400,700\' rel=\'stylesheet\' type=\'text/css\'>')
-print('<link rel="stylesheet" href="https://www.plumed.org//assets/css/style.css?v=9dd2bd3d9ee4823fb5d3485bda969afbaa1ba8d4">')
-print('<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">')
-print('<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jszip-2.5.0/dt-1.10.18/b-1.5.6/b-flash-1.5.6/b-html5-1.5.6/datatables.min.css"/>')
-print('<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jq-3.3.1/jszip-2.5.0/dt-1.10.18/b-1.5.6/b-flash-1.5.6/b-html5-1.5.6/datatables.min.css"/>')
-print('<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/pdfmake.min.js"></script>')
-print('<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/vfs_fonts.js"></script>')
-print('<script type="text/javascript" src="https://cdn.datatables.net/v/dt/jq-3.3.1/jszip-2.5.0/dt-1.10.18/b-1.5.6/b-flash-1.5.6/b-html5-1.5.6/datatables.min.js"></script>')
+print(
+  "<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>"
+)
+print(
+  '<link rel="stylesheet" href="https://www.plumed.org//assets/css/style.css?v=9dd2bd3d9ee4823fb5d3485bda969afbaa1ba8d4">'
+)
+print(
+  '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">'
+)
+print(
+  '<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jszip-2.5.0/dt-1.10.18/b-1.5.6/b-flash-1.5.6/b-html5-1.5.6/datatables.min.css"/>'
+)
+print(
+  '<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jq-3.3.1/jszip-2.5.0/dt-1.10.18/b-1.5.6/b-flash-1.5.6/b-html5-1.5.6/datatables.min.css"/>'
+)
+print(
+  '<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/pdfmake.min.js"></script>'
+)
+print(
+  '<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/vfs_fonts.js"></script>'
+)
+print(
+  '<script type="text/javascript" src="https://cdn.datatables.net/v/dt/jq-3.3.1/jszip-2.5.0/dt-1.10.18/b-1.5.6/b-flash-1.5.6/b-html5-1.5.6/datatables.min.js"></script>'
+)
 print('<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>')
 print('<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>')
-print('</head>')
-print('<body>')
+print("</head>")
+print("<body>")
 print('<section class="page-header">')
-print('<a href="https://github.com/plumed/plumed2"><img style="position:absolute; top:10px; right:100px; width:50px" src="https://www.plumed.org//Octocat.png" title="Get development version"></a>')
-print('<a href="https://github.com/plumed/plumed2/releases/download/v2.8.0/plumed-2.8.0.tgz"><img style="position:absolute; top:10px; right:40px; width:40px" src="https://www.plumed.org//arrow.png" title="Get latest release"></a>')
-print('<a class="site-title" href="http://www.plumed.org"><img width="220" src="pigeon-teacher.png"></a>')
+print(
+  '<a href="https://github.com/plumed/plumed2"><img style="position:absolute; top:10px; right:100px; width:50px" src="https://www.plumed.org//Octocat.png" title="Get development version"></a>'
+)
+print(
+  '<a href="https://github.com/plumed/plumed2/releases/download/v2.8.0/plumed-2.8.0.tgz"><img style="position:absolute; top:10px; right:40px; width:40px" src="https://www.plumed.org//arrow.png" title="Get latest release"></a>'
+)
+print(
+  '<a class="site-title" href="http://www.plumed.org"><img width="220" src="pigeon-teacher.png"></a>'
+)
 print('<h1 class="project-name">PLUMED</h1>')
-print('<h2 class="project-tagline">The community-developed PLUgin for MolEcular Dynamics</h2>')
-print('</section>')
+print(
+  '<h2 class="project-tagline">The community-developed PLUgin for MolEcular Dynamics</h2>'
+)
+print("</section>")
 print('<section class="main-content">', flush=True)
 # Putting this here You can see render the page while it is being generated
-print( PlumedToHTML.get_html_header() )
+print(PlumedToHTML.get_html_header())
 f = open("./tdata/tests.json")
 tests = json.load(f)
 f.close()
 
-for item in tests["regtests"] :
-    actions = set({})
-    out = PlumedToHTML.test_and_get_html( item["input"], "plinp" + str(item["index"]), actions=actions )
-    
-    print(f"<h3>Input number {item['index']}</h3>")
-    #this visualizes the "from-to" and it is more clear to eye-check what is going on
-    print("<pre>")
-    print(item["input"])
-    print("</pre>")
-    print( out )
+for item in tests["regtests"]:
+  actions = set({})
+  out = PlumedToHTML.test_and_get_html(
+    item["input"], "plinp" + str(item["index"]), actions=actions
+  )
+
+  print(f"<h3>Input number {item['index']}</h3>")
+  # this visualizes the "from-to" and it is more clear to eye-check what is going on
+  print("<pre>")
+  print(item["input"])
+  print("</pre>")
+  print(out)
 
 f = open("./tdata/cltooltests.json")
 tests = json.load(f)
 f.close()
 
-for item in tests["regtests"] :
-    out = PlumedToHTML.get_cltoolarg_html( item["input"], "clinp" + str(item["index"]), ("plumed",) )
-    #this visualizes the "from-to" and it is more clear to eye-check what is going on
-    print(f"<h3>CL tool input number {item['index']}</h3>")
-    print("<pre>")
-    print(item["input"])
-    print("</pre>")
-    print( out )
+for item in tests["regtests"]:
+  out = PlumedToHTML.get_cltoolarg_html(
+    item["input"], "clinp" + str(item["index"]), ("plumed",)
+  )
+  # this visualizes the "from-to" and it is more clear to eye-check what is going on
+  print(f"<h3>CL tool input number {item['index']}</h3>")
+  print("<pre>")
+  print(item["input"])
+  print("</pre>")
+  print(out)
 
 f = open("./tdata/clfiletests.json")
 tests = json.load(f)
 f.close()
 
-for item in tests["regtests"] :
-    out = PlumedToHTML.get_cltoolfile_html( item["input"], "clinp" + str(item["index"]), ("plumed",) )
-    #this visualizes the "from-to" and it is more clear to eye-check what is going on
-    print(f"<h3>CL file input number {item['index']}</h3>")
-    print("<pre>")
-    print(item["input"])
-    print("</pre>")
-    print( out )
+for item in tests["regtests"]:
+  out = PlumedToHTML.get_cltoolfile_html(
+    item["input"], "clinp" + str(item["index"]), ("plumed",)
+  )
+  # this visualizes the "from-to" and it is more clear to eye-check what is going on
+  print(f"<h3>CL file input number {item['index']}</h3>")
+  print("<pre>")
+  print(item["input"])
+  print("</pre>")
+  print(out)
 
-print('</section>')
-print('</body>')
-print('</html>')
+print("</section>")
+print("</body>")
+print("</html>")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,28 +57,31 @@ where = ["src"]
 #we state which files we want to include per package
 PlumedToHTML = ['assets/*.html']
 
+[tool.ruff]
+indent-width = 2
+
 #this is not elegant, but having all the settings in a single file is cozier
 [tool.tox]
-legacy_tox_ini = """
-[tox]
-env_list =
-    tests
-    lint
+requires = ["tox>=4.19"]
+#enviroments run by simply calling "tox"
+envlist=["format", "linting" , "tests"]
 
-[testenv:tests]
-deps = pytest
-       pytest-cov
-commands = pytest --cov=PlumedToHTML --cov-report=term-missing
+[tool.tox.env_run_base]
+deps = ["pytest", "pytest-cov"]
+commands = [[ "pytest", "tests", "--cov=PlumedToHTML",  "--cov-report=term-missing"]]
 
-[pytest]
-testpaths =
-    tests
-
-[testenv:lint]
+[tool.tox.env.linting]
 skip_install = true
-deps = 
-    ruff==0.9.6
-commands = 
-    ruff check src/PlumedToHTML
-    ruff format src/PlumedToHTML --check
-"""
+deps = ["ruff==0.9.6"]
+commands = [["ruff", "check", "src/PlumedToHTML", "tests"]]
+
+[tool.tox.env.format]
+skip_install = true
+deps = ["ruff==0.9.6"]
+commands = [["ruff", "format", "src/PlumedToHTML", "tests"]]
+
+[tool.tox.env.check-format]
+skip_install = true
+deps = ["ruff==0.9.6"]
+commands = [["ruff", "format", "--check", "src/PlumedToHTML", "tests"]]
+

--- a/src/PlumedToHTML/PlumedCLFileLexer.py
+++ b/src/PlumedToHTML/PlumedCLFileLexer.py
@@ -1,24 +1,25 @@
-from pygments.lexer import RegexLexer, bygroups, include
-from pygments.token import Text, Keyword, Name, String, Comment
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import Text, Keyword, Name, Comment
+
 
 class PlumedCLFileLexer(RegexLexer):
-    name = 'plumedclfile'
-    aliases = ['plumedclfile']
-    filenames = ['*.plmd']
+  name = "plumedclfile"
+  aliases = ["plumedclfile"]
+  filenames = ["*.plmd"]
 
-    tokens = {
-        'root': [
-            # Find the start of a shortcut with a nested default
-            (r'#NODEFAULT plumed\n',Comment.Special),
-            # Find the start of a default section
-            (r'#DEFAULT plumed\n',Comment.Special),
-            # Find the end of a default section
-            (r'#ENDDEFAULT plumed\n',Comment.Special),
-            # The name of the tool that this is an input file for
-            (r'(#TOOL=\s*)(\S+\b)',bygroups( Comment, Keyword )),
-            # The lines of instruction for the file  
-            (r'(\S+\b)(\s+)(.+$)',bygroups(Name.Attribute, Text, Text)),
-            # Find any left over white space
-            (r'\s+',Text)
-        ]
-    }
+  tokens = {
+    "root": [
+      # Find the start of a shortcut with a nested default
+      (r"#NODEFAULT plumed\n", Comment.Special),
+      # Find the start of a default section
+      (r"#DEFAULT plumed\n", Comment.Special),
+      # Find the end of a default section
+      (r"#ENDDEFAULT plumed\n", Comment.Special),
+      # The name of the tool that this is an input file for
+      (r"(#TOOL=\s*)(\S+\b)", bygroups(Comment, Keyword)),
+      # The lines of instruction for the file
+      (r"(\S+\b)(\s+)(.+$)", bygroups(Name.Attribute, Text, Text)),
+      # Find any left over white space
+      (r"\s+", Text),
+    ]
+  }

--- a/src/PlumedToHTML/PlumedCLtoolLexer.py
+++ b/src/PlumedToHTML/PlumedCLtoolLexer.py
@@ -1,48 +1,64 @@
-from pygments.lexer import RegexLexer, bygroups, include
+from pygments.lexer import RegexLexer, bygroups
 from pygments.token import Text, Keyword, Name, String, Comment, Literal
 
-class PlumedCLtoolLexer(RegexLexer):
-    name = 'plumedcltool'
-    aliases = ['plumedcltool']
-    filenames = ['*.plmd']
 
-    tokens = {
-        'root': [
-            # Find the start of a shortcut with a nested default
-            (r'#NODEFAULT plumed\n',Comment.Special),
-            # Find the start of a default section
-            (r'#DEFAULT plumed\n',Comment.Special),
-            # Find the end of a default section
-            (r'#ENDDEFAULT plumed\n',Comment.Special),
-            # Find commands that use MPI and that take an input file
-            (r'(^\s*mpirun\s+-np)(\s+[0-9]+\s+)(plumed)(\s+)(\S+\b)(\s*<\s*)(\S+\b)', bygroups(Literal, Text, String, Text, Keyword, Text, Name.Decorator)), 
-            # With plumed-runtime and MPI
-            (r'(^\s*mpirun\s+-np)(\s+[0-9]+\s+)(plumed-runtime)(\s+)(\S+\b)', bygroups(Literal, Text, String, Text, Keyword)),
-            # Find commands that use MPI
-            (r'(^\s*mpirun\s+-np)(\s+[0-9]+\s+)(plumed)(\s+)(\S+\b)', bygroups(Literal, Text, String, Text, Keyword)),
-            # Find commands that use the nompi flag
-            (r'(^\s*plumed)(\s+)(--no-mpi)(\s+)(\S+\b)', bygroups(String, Text, Literal, Text, Keyword)),
-            # Find commands that take an input file
-            (r'(^\s*plumed)(\s+)(\S+\b)(\s*<\s*)(\S+\b)', bygroups(String, Text, Keyword, Text, Name.Decorator)),
-            # Find direct out to file
-            (r'(\s*>\s*)(\S+\b)', bygroups(Text, Name.Entity)),
-            # Find the name of the command if we are using plumed-runtime
-            (r'(^\s*plumed-runtime)(\s+)(\S+\b)', bygroups(String, Text, Keyword)),
-            # Find the name of the command
-            (r'(^\s*plumed)(\s+)(\S+\b)', bygroups(String, Text, Keyword)),
-            # Deals with keywords with argument in inverted commas
-            (r'(-\S+)(=)(".+")', bygroups(Name.Attribute, Text, Text)),
-            # Deals with keywords with equals sign
-            (r'(-\S+)(=)(\S+\b)', bygroups(Name.Attribute, Text, Text)),
-            # Flag at end of line
-            (r'(--\S+\b)(\s*\n)', bygroups(Name.Attribute, Text)),
-            # Deals with keywords
-            (r'(--\S+)(\s+)([^-\s]+\b)', bygroups(Name.Attribute, Text, Text)),
-            # Deals with flags
-            (r'(--\S+\b)', Name.Attribute),
-            # find the -h command
-            (r'(-h)', Name.Attribute),
-            # Find any left over white space
-            (r'\s+',Text)
-        ]
-    }
+class PlumedCLtoolLexer(RegexLexer):
+  name = "plumedcltool"
+  aliases = ["plumedcltool"]
+  filenames = ["*.plmd"]
+
+  tokens = {
+    "root": [
+      # Find the start of a shortcut with a nested default
+      (r"#NODEFAULT plumed\n", Comment.Special),
+      # Find the start of a default section
+      (r"#DEFAULT plumed\n", Comment.Special),
+      # Find the end of a default section
+      (r"#ENDDEFAULT plumed\n", Comment.Special),
+      # Find commands that use MPI and that take an input file
+      (
+        r"(^\s*mpirun\s+-np)(\s+[0-9]+\s+)(plumed)(\s+)(\S+\b)(\s*<\s*)(\S+\b)",
+        bygroups(Literal, Text, String, Text, Keyword, Text, Name.Decorator),
+      ),
+      # With plumed-runtime and MPI
+      (
+        r"(^\s*mpirun\s+-np)(\s+[0-9]+\s+)(plumed-runtime)(\s+)(\S+\b)",
+        bygroups(Literal, Text, String, Text, Keyword),
+      ),
+      # Find commands that use MPI
+      (
+        r"(^\s*mpirun\s+-np)(\s+[0-9]+\s+)(plumed)(\s+)(\S+\b)",
+        bygroups(Literal, Text, String, Text, Keyword),
+      ),
+      # Find commands that use the nompi flag
+      (
+        r"(^\s*plumed)(\s+)(--no-mpi)(\s+)(\S+\b)",
+        bygroups(String, Text, Literal, Text, Keyword),
+      ),
+      # Find commands that take an input file
+      (
+        r"(^\s*plumed)(\s+)(\S+\b)(\s*<\s*)(\S+\b)",
+        bygroups(String, Text, Keyword, Text, Name.Decorator),
+      ),
+      # Find direct out to file
+      (r"(\s*>\s*)(\S+\b)", bygroups(Text, Name.Entity)),
+      # Find the name of the command if we are using plumed-runtime
+      (r"(^\s*plumed-runtime)(\s+)(\S+\b)", bygroups(String, Text, Keyword)),
+      # Find the name of the command
+      (r"(^\s*plumed)(\s+)(\S+\b)", bygroups(String, Text, Keyword)),
+      # Deals with keywords with argument in inverted commas
+      (r'(-\S+)(=)(".+")', bygroups(Name.Attribute, Text, Text)),
+      # Deals with keywords with equals sign
+      (r"(-\S+)(=)(\S+\b)", bygroups(Name.Attribute, Text, Text)),
+      # Flag at end of line
+      (r"(--\S+\b)(\s*\n)", bygroups(Name.Attribute, Text)),
+      # Deals with keywords
+      (r"(--\S+)(\s+)([^-\s]+\b)", bygroups(Name.Attribute, Text, Text)),
+      # Deals with flags
+      (r"(--\S+\b)", Name.Attribute),
+      # find the -h command
+      (r"(-h)", Name.Attribute),
+      # Find any left over white space
+      (r"\s+", Text),
+    ]
+  }

--- a/src/PlumedToHTML/PlumedFormatter.py
+++ b/src/PlumedToHTML/PlumedFormatter.py
@@ -3,357 +3,824 @@ from pygments.formatter import Formatter
 from pygments.token import Text, Comment, Literal, Keyword, Name, Generic, String
 from pygments.lexers.c_cpp import CppLexer
 from pygments.formatters import HtmlFormatter
-from requests.exceptions import InvalidJSONError
 import re
 import html
-import json
+
 
 class PlumedFormatter(Formatter):
-    def __init__(self, **options) :
-        Formatter.__init__(self, **options) 
-        # Retrieve the dictionary of keywords from the json
-        self.keyword_dict=options["keyword_dict"]
-        self.divname=options["input_name"]
-        self.egname=options["input_name"]
-        self.hasload=options["hasload"]
-        self.broken=options["broken"]
-        self.auxinputs=options["auxinputs"]
-        self.auxinputlines=options["auxinputlines"]
-        self.valuedict=options["valuedict"]
-        self.actions=options["actions"]
-        self.checkaction=options["checkaction"]
-        self.checkaction_keywords = set({})
-        self.valcolors = { 
-           "scalar": "black", 
-           "atoms": "violet", 
-           "vector": "blue", 
-           "matrix": "red", 
-           "grid": "green", 
-           "mix": "brown" 
-        }
+  def __init__(self, **options):
+    Formatter.__init__(self, **options)
+    # Retrieve the dictionary of keywords from the json
+    self.keyword_dict = options["keyword_dict"]
+    self.divname = options["input_name"]
+    self.egname = options["input_name"]
+    self.hasload = options["hasload"]
+    self.broken = options["broken"]
+    self.auxinputs = options["auxinputs"]
+    self.auxinputlines = options["auxinputlines"]
+    self.valuedict = options["valuedict"]
+    self.actions = options["actions"]
+    self.checkaction = options["checkaction"]
+    self.checkaction_keywords = set({})
+    self.valcolors = {
+      "scalar": "black",
+      "atoms": "violet",
+      "vector": "blue",
+      "matrix": "red",
+      "grid": "green",
+      "mix": "brown",
+    }
 
-    def format(self, tokensource, outfile):
-        action, label, all_labels, keywords, shortcut_state, shortcut_depth, default_state, notooltips, expansion_label, hidden_state, hidenum, nfiles = "", "", set(), [], 0, 0, 0, False, "", 0, 0, 0
-        outfile.write('<pre class="plumedlisting">\n')
-        for ttype, value in tokensource :
-            # This checks if we are at the start of a new action.  If we are we should be reading a value or an action and the label and action for the previous one should be set
-            if len(action)>0 and (ttype==String or ttype==Keyword or ttype==Comment.Preproc) :
-               if action==self.checkaction : 
-                  self.storeKeywordsForCheckAction( keywords )
-               if notooltips : 
-                  # Reset everything for the new action
-                  action, label, keywords, notooltips = "", "", [], False
-               else :
-                  # This outputs information on the values computed in the previous action for the header
-                  if label not in self.valuedict.keys() and label not in all_labels : 
-                     all_labels.add(label)
-                     if action in self.keyword_dict and "output" in self.keyword_dict[action]["syntax"] : self.writeValuesData( outfile, action, label, keywords, self.keyword_dict[action]["syntax"]["output"] )
-                     else : 
-                        outfile.write('<span style="display:none;" id="' + self.egname + label + r'">')
-                        outfile.write('The ' + action + ' action with label <b>' + label + '</b> calculates something') 
-                        outfile.write('</span>') 
-                  # Reset everything for the new action
-                  action, label, keywords = "", "", []
+  def format(self, tokensource, outfile):
+    (
+      action,
+      label,
+      all_labels,
+      keywords,
+      shortcut_state,
+      shortcut_depth,
+      default_state,
+      notooltips,
+      expansion_label,
+      hidden_state,
+      hidenum,
+      nfiles,
+    ) = "", "", set(), [], 0, 0, 0, False, "", 0, 0, 0
+    outfile.write('<pre class="plumedlisting">\n')
+    for ttype, value in tokensource:
+      # This checks if we are at the start of a new action.  If we are we should be reading a value or an action and the label and action for the previous one should be set
+      if len(action) > 0 and (
+        ttype == String or ttype == Keyword or ttype == Comment.Preproc
+      ):
+        if action == self.checkaction:
+          self.storeKeywordsForCheckAction(keywords)
+        if notooltips:
+          # Reset everything for the new action
+          action, label, keywords, notooltips = "", "", [], False
+        else:
+          # This outputs information on the values computed in the previous action for the header
+          if label not in self.valuedict.keys() and label not in all_labels:
+            all_labels.add(label)
+            if (
+              action in self.keyword_dict
+              and "output" in self.keyword_dict[action]["syntax"]
+            ):
+              self.writeValuesData(
+                outfile,
+                action,
+                label,
+                keywords,
+                self.keyword_dict[action]["syntax"]["output"],
+              )
+            else:
+              outfile.write(
+                '<span style="display:none;" id="' + self.egname + label + r'">'
+              )
+              outfile.write(
+                "The "
+                + action
+                + " action with label <b>"
+                + label
+                + "</b> calculates something"
+              )
+              outfile.write("</span>")
+          # Reset everything for the new action
+          action, label, keywords = "", "", []
 
-            # Check users inputs for rogue # symbols that have been lexed into the wrong place
-            if "#" in value and ttype!=Comment and ttype!=Comment.Hashbang and ttype!=Comment.Special and ttype!=Comment.Preproc and ttype!=Literal : 
-                raise ValueError("found # in {" + value + "} but this string has not been identified as a comment by the lexer.  If you have colons in your comments they are known to cause this error.  If you remove the colons from the comments the input may parse.")
+      # Check users inputs for rogue # symbols that have been lexed into the wrong place
+      if (
+        "#" in value
+        and ttype != Comment
+        and ttype != Comment.Hashbang
+        and ttype != Comment.Special
+        and ttype != Comment.Preproc
+        and ttype != Literal
+      ):
+        raise ValueError(
+          "found # in {"
+          + value
+          + "} but this string has not been identified as a comment by the lexer.  If you have colons in your comments they are known to cause this error.  If you remove the colons from the comments the input may parse."
+        )
 
-            if ttype==Text.Whitespace :
-               # Blank lines
-               outfile.write( '<br/>' )
-            elif ttype==Text :
-               # Non PLUMED stuff
-               outfile.write( value )
-            elif ttype==Literal :
-               # mpirun -np for command line tools
-               if re.search(r"mpirun\s+-np", value ) :
-                   outfile.write('<span class="plumedtooltip">' + value + '<span class="right">Run instances of PLUMED on this number of MPI processes<i></i></span></span>') 
-               # --no-mpmi for command such as plumed --no-mpi tool ...
-               elif value=="--no-mpi" :
-                   outfile.write('<span class="plumedtooltip">' + value + '<span class="right">Ignore any mpirun commands and turn off MPI.<i></i></span></span>')
-               # __FILL__ for incomplete values
-               elif value=="__FILL__"  : 
-                   outfile.write('<span style="background-color:yellow">__FILL__</span>')
-               # This is for vim syntax expression
-               elif "vim:" in value :
-                   outfile.write('<span class="plumedtooltip" style="color:blue">' + value + '<span class="right">Enables syntax highlighting for PLUMED files in vim. See <a href="' + self.keyword_dict["vimlink"] + '">here for more details. </a><i></i></span></span>')
-               else : raise ValueError("found invalid Literal in input " + value)
-            elif ttype==Comment.Hashbang :
-               # This handles the mechanism for closing the expanding shortcut
-               if shortcut_state!=2 : raise ValueError("Should only find line to close shortcut between #EXPANSION and #ENDEXPANSION tags")
-               outfile.write('<span class="toggler" style="color:red" onclick=\'toggleDisplay("' + self.egname + expansion_label + '")\'>' + value + '</span>')
-            elif ttype==Comment.Special or ttype==Comment.Preproc :
-               # This handles the mechanisms for the expandable shortcuts
-               act_label=""
-               if "#NODEFAULT" in value :
-                  if default_state!=0 : raise ValueError("Found rogue #NODEFAULT")
-                  default_state, act_label = 1, html.escape( value.replace("#NODEFAULT","").strip() )
-                  outfile.write('<span id="' + self.egname + "def" + act_label + '_short">')
-               elif "#ENDDEFAULT" in value :
-                  if default_state!=2 : raise ValueError("Found rogue #ENDDEFAULT")
-                  default_state = 0
-                  outfile.write('</span>')
-               elif "#DEFAULT" in value :
-                  if default_state!=1 : raise ValueError("Found rogue #DEFAULT")
-                  act_label, default_state = html.escape( value.replace("#DEFAULT","").strip() ), 2
-                  outfile.write('</span><span id="' + self.egname + "def" + act_label + '_long" style="display:none;">')
-               elif "#SHORTCUT" in value :
-                  if shortcut_depth==0 and shortcut_state!=0 : raise ValueError("Found rogue #SHORTCUT")
-                  shortcut_state, shortcut_depth = 1, shortcut_depth + 1
-                  act_label = html.escape( value.replace("#SHORTCUT","").strip() )
-                  outfile.write('<span id="' + self.egname + act_label + '_short">')
-               elif "#ENDEXPANSION" in value :
-                  if shortcut_state!=2 : raise ValueError("Should only find #ENDEXPANSION tag after #EXPANSION tag")
-                  shortcut_depth = shortcut_depth - 1
-                  if shortcut_depth==0 : shortcut_state=0
-                  act_label = html.escape( value.replace("#ENDEXPANSION","").strip() )
-                  # Now output the end of the expansion
-                  outfile.write('<span style="color:blue"># --- End of included input --- </span></span>')
-               elif "#EXPANSION" in value :
-                  if shortcut_state!=1 : raise ValueError("Should only find #EXPANSION tag after #SHORTCUT tag")
-                  shortcut_state = 2
-                  act_label, expansion_label = html.escape( value.replace("#EXPANSION","").strip() ), value.replace("#EXPANSION","").strip()
-                  outfile.write('</span><span id="' + self.egname + act_label + '_long" style="display:none;">')
-               elif "#ENDHIDDEN" in value :
-                  if hidden_state != 1 : raise ValueError("Found rogue #ENDHIDDEN")
-                  hidden_state = 0 
-                  outfile.write('<a class="toggler" style="color:red" onclick=\'toggleDisplay("' + self.egname + "_hiddenpart" + str(hidenum) + '")\'># --- Click here to hide input --- \n</a></span>')
-               elif "#HIDDEN" in value :
-                  if hidden_state != 0 : raise ValueError("Found rogue #HIDDEN in already hidden input") 
-                  hidden_state, hidenum = 1, hidenum + 1
-                  outfile.write('<span id="' + self.egname + "_hiddenpart" + str(hidenum) + '_short">')
-                  outfile.write('<a class="toggler" style="color:red" onclick=\'toggleDisplay("' + self.egname + "_hiddenpart" + str(hidenum) + '")\'># --- Click here to reveal hidden parts of input file ---- \n</a></span>')
-                  outfile.write('<span id="' + self.egname + "_hiddenpart" + str(hidenum) + '_long" style="display:none;">')
-               else : raise ValueError("Found " + value.strip() + " in Comment.Special should only catch string that are #SHORTCUT, #EXPANSION, #ENDEXPANSION, #HIDDEN or #ENDHIDDEN")
-               # This sets up the label at the start of a new block with NODEFAULT or SHORTCUT
-               if ttype==Comment.Preproc :
-                  if label!="" and label!=act_label : raise Exception("label for shortcut (" + act_label + ") doesn't match action label (" + label + ")")
-                  elif label=="" : label = act_label 
-            elif ttype==Generic:
-               # whatever in KEYWORD=whatever 
-               if action=="INCLUDE" and shortcut_state==1 : 
-                  # special treatment for filename in INCLUDE FILE=filename
-                  outfile.write('<a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + label + '");\'>' + value + '</a>') 
-               else :
-                  # notice special treatment here because we want to find labels so we can show paths
-                  inputs, nocomma = value.split(","), True
-                  for inp in inputs : 
-                      islab, inpt = False, inp.strip()
-                      for lab in all_labels : 
-                          if inpt.split('.')[0]==lab : 
-                             islab=True
-                             break
-                      if not nocomma : outfile.write(',')
-                      if islab : outfile.write('<b name="' + self.egname + inpt.split('.')[0] + '">' + inp + '</b>')
-                      # Deal with files
-                      elif inp in self.auxinputs :
-                        iff = open( inp, 'r' )
-                        fcontent = iff.read()
-                        iff.close()
-                        # This does syntax highlighting on cpp files 
-                        if inp.split(".")[-1]=="cpp" : fcontent = highlight( fcontent, CppLexer(), HtmlFormatter() )
-                        nfiles = nfiles + 1
-                        if len(self.auxinputlines)>0 : 
-                           shortversion, allines = "", fcontent.splitlines()
-                           for n, l in enumerate(self.auxinputlines) : 
-                               bounds = l.split("-")
-                               start, end = int( bounds[0] ), int( bounds[1] )
-                               if start>len(allines) : break
-                               if n>0 : shortversion += "...\n"
-                               for kk in range(start,end+1) : 
-                                   if kk<=len(allines) : shortversion += allines[kk-1] + "\n"
-                           fcontent = shortversion
-                        outfile.write('<div class="plumedtooltip">' + inp + '<div class="right"> Click <a onclick=\'openModal("' + self.egname + inp + str(nfiles) + '")\'>here</a> to see an extract from this file.<i></i></div></div>')
-                        outfile.write('<div id="' + self.egname + inp + str(nfiles) + '" class="plumedmodal">')
-                        outfile.write('  <div class="plumedmodal-content">')
-                        outfile.write('<div class="plumedmodal-header">')
-                        outfile.write('  <span class="close" onclick=\'closeModal("' + self.egname + inp + str(nfiles) + '")\'>&times;</span>')
-                        outfile.write('  <h2>FILE: ' + inp + '</h2>')
-                        outfile.write('</div>')
-                        outfile.write('<div class="plumedmodal-body">')
-                        outfile.write('    <pre>' + fcontent + '</pre>')
-                        outfile.write('</div>')
-                        outfile.write('  </div>')
-                        outfile.write('</div>')
-                      # Deal with atom selections
-                      elif "@" in inp :
-                        tooltip, link = "", ""
-                        # Deal with residue
-                        if "-" in inp : 
-                            select, defs, residue = "", inp.split("-"), "" 
-                            if "_" in defs[1] : 
-                                resp = defs[1].split("_")
-                                residue = "residue " + resp[1] + " in chain " + resp[0]
-                            else : residue = "residue " + defs[1]  
-                            select = defs[0] + "-"
-                            if select not in self.keyword_dict["groups"] : tooltip, link = "the " + defs[0][1:] + " atom in " + residue, self.keyword_dict["groups"]["@protein"]["link"]
-                            else : tooltip, link = self.keyword_dict["groups"][select]["description"] + " " + residue, self.keyword_dict["groups"][select]["link"]
-                        else : 
-                            select = inp.strip()
-                            if select in self.keyword_dict["groups"] : tooltip, link = self.keyword_dict["groups"][select]["description"], self.keyword_dict["groups"][select]["link"]
-                        if len(tooltip)>0 : outfile.write('<span class="plumedtooltip">' + inp + '<span class="right">' + tooltip + '. <a href="' + link + '">Click here</a> for more information. <i></i></span></span>') 
-                        else : outfile.write( html.escape(inp) )
-                      else : outfile.write( html.escape(inp) )
-                      nocomma = False 
-            elif ttype==String or ttype==String.Double :
-               # Labels of actions
-               if not self.broken and action!="" and label!="" and label!=value.strip() : raise Exception("label for " + action + " is not what is expected.  Is " + label + " should be " + value.strip() )
-               elif value.strip()=="plumed-runtime" : label = "plumed"
-               elif label=="" : label = html.escape( value.strip() ) 
-               valtype = "mix"
-               if label in self.valuedict.keys() :
-                  valtype = "unset"
-                  for key, ddd in self.valuedict[label].items() :
-                      if key=="action" : continue
-                      elif valtype=="unset" : valtype = ddd["type"]
-                      elif valtype!=ddd["type"] : valtype = "mix" 
-               if shortcut_state==1 and "shortcut_" + label in self.valuedict.keys() : 
-                  outfile.write('<b name="' + self.egname + label + '" onclick=\'showPath("' + self.divname + '","' + self.egname + label + '","' + self.egname + label + '_shortcut","' + self.valcolors[valtype] + '")\'>' + value + '</b>') 
-                  if label + "_shortcut" not in all_labels :
-                     all_labels.add(label + "_shortcut") 
-                     self.writeValueInfo( outfile, label, label + "_shortcut", self.valuedict["shortcut_" + label] )
-               else : 
-                  outfile.write('<b name="' + self.egname + label + '" onclick=\'showPath("' + self.divname + '","' + self.egname + label + '","' + self.egname + label + '","' + self.valcolors[valtype] + '")\'>' + value + '</b>')
-                  if label in self.valuedict.keys() and label not in all_labels :
-                     all_labels.add(label)
-                     self.writeValueInfo( outfile, label, label, self.valuedict[label] )
-            elif ttype==Comment :
-               # Comments
-               outfile.write('<span style="color:blue" class="comment">' + html.escape(value) + '</span>' )
-            elif ttype==Name.Attribute :
-               # KEYWORD in KEYWORD=whatever and FLAGS
-               keywords.append( value.strip().upper() )
-               if notooltips :
-                  outfile.write( value.strip() )
-               else :
-                  desc, mykey = "", value.strip().upper()
-                  if action not in self.keyword_dict : raise Exception("action " + action + " not present in keyword dictionary")
-                  if "syntax" not in self.keyword_dict[action] : raise Exception("syntax not present in documentation for " + action )
-                  if mykey not in self.keyword_dict[action]["syntax"] and value.strip() in self.keyword_dict[action]["syntax"] : mykey = value.strip()
+      if ttype == Text.Whitespace:
+        # Blank lines
+        outfile.write("<br/>")
+      elif ttype == Text:
+        # Non PLUMED stuff
+        outfile.write(value)
+      elif ttype == Literal:
+        # mpirun -np for command line tools
+        if re.search(r"mpirun\s+-np", value):
+          outfile.write(
+            '<span class="plumedtooltip">'
+            + value
+            + '<span class="right">Run instances of PLUMED on this number of MPI processes<i></i></span></span>'
+          )
+        # --no-mpmi for command such as plumed --no-mpi tool ...
+        elif value == "--no-mpi":
+          outfile.write(
+            '<span class="plumedtooltip">'
+            + value
+            + '<span class="right">Ignore any mpirun commands and turn off MPI.<i></i></span></span>'
+          )
+        # __FILL__ for incomplete values
+        elif value == "__FILL__":
+          outfile.write('<span style="background-color:yellow">__FILL__</span>')
+        # This is for vim syntax expression
+        elif "vim:" in value:
+          outfile.write(
+            '<span class="plumedtooltip" style="color:blue">'
+            + value
+            + '<span class="right">Enables syntax highlighting for PLUMED files in vim. See <a href="'
+            + self.keyword_dict["vimlink"]
+            + '">here for more details. </a><i></i></span></span>'
+          )
+        else:
+          raise ValueError("found invalid Literal in input " + value)
+      elif ttype == Comment.Hashbang:
+        # This handles the mechanism for closing the expanding shortcut
+        if shortcut_state != 2:
+          raise ValueError(
+            "Should only find line to close shortcut between #EXPANSION and #ENDEXPANSION tags"
+          )
+        outfile.write(
+          '<span class="toggler" style="color:red" onclick=\'toggleDisplay("'
+          + self.egname
+          + expansion_label
+          + "\")'>"
+          + value
+          + "</span>"
+        )
+      elif ttype == Comment.Special or ttype == Comment.Preproc:
+        # This handles the mechanisms for the expandable shortcuts
+        act_label = ""
+        if "#NODEFAULT" in value:
+          if default_state != 0:
+            raise ValueError("Found rogue #NODEFAULT")
+          default_state, act_label = (
+            1,
+            html.escape(value.replace("#NODEFAULT", "").strip()),
+          )
+          outfile.write('<span id="' + self.egname + "def" + act_label + '_short">')
+        elif "#ENDDEFAULT" in value:
+          if default_state != 2:
+            raise ValueError("Found rogue #ENDDEFAULT")
+          default_state = 0
+          outfile.write("</span>")
+        elif "#DEFAULT" in value:
+          if default_state != 1:
+            raise ValueError("Found rogue #DEFAULT")
+          act_label, default_state = (
+            html.escape(value.replace("#DEFAULT", "").strip()),
+            2,
+          )
+          outfile.write(
+            '</span><span id="'
+            + self.egname
+            + "def"
+            + act_label
+            + '_long" style="display:none;">'
+          )
+        elif "#SHORTCUT" in value:
+          if shortcut_depth == 0 and shortcut_state != 0:
+            raise ValueError("Found rogue #SHORTCUT")
+          shortcut_state, shortcut_depth = 1, shortcut_depth + 1
+          act_label = html.escape(value.replace("#SHORTCUT", "").strip())
+          outfile.write('<span id="' + self.egname + act_label + '_short">')
+        elif "#ENDEXPANSION" in value:
+          if shortcut_state != 2:
+            raise ValueError("Should only find #ENDEXPANSION tag after #EXPANSION tag")
+          shortcut_depth = shortcut_depth - 1
+          if shortcut_depth == 0:
+            shortcut_state = 0
+          act_label = html.escape(value.replace("#ENDEXPANSION", "").strip())
+          # Now output the end of the expansion
+          outfile.write(
+            '<span style="color:blue"># --- End of included input --- </span></span>'
+          )
+        elif "#EXPANSION" in value:
+          if shortcut_state != 1:
+            raise ValueError("Should only find #EXPANSION tag after #SHORTCUT tag")
+          shortcut_state = 2
+          act_label, expansion_label = (
+            html.escape(value.replace("#EXPANSION", "").strip()),
+            value.replace("#EXPANSION", "").strip(),
+          )
+          outfile.write(
+            '</span><span id="'
+            + self.egname
+            + act_label
+            + '_long" style="display:none;">'
+          )
+        elif "#ENDHIDDEN" in value:
+          if hidden_state != 1:
+            raise ValueError("Found rogue #ENDHIDDEN")
+          hidden_state = 0
+          outfile.write(
+            '<a class="toggler" style="color:red" onclick=\'toggleDisplay("'
+            + self.egname
+            + "_hiddenpart"
+            + str(hidenum)
+            + "\")'># --- Click here to hide input --- \n</a></span>"
+          )
+        elif "#HIDDEN" in value:
+          if hidden_state != 0:
+            raise ValueError("Found rogue #HIDDEN in already hidden input")
+          hidden_state, hidenum = 1, hidenum + 1
+          outfile.write(
+            '<span id="' + self.egname + "_hiddenpart" + str(hidenum) + '_short">'
+          )
+          outfile.write(
+            '<a class="toggler" style="color:red" onclick=\'toggleDisplay("'
+            + self.egname
+            + "_hiddenpart"
+            + str(hidenum)
+            + "\")'># --- Click here to reveal hidden parts of input file ---- \n</a></span>"
+          )
+          outfile.write(
+            '<span id="'
+            + self.egname
+            + "_hiddenpart"
+            + str(hidenum)
+            + '_long" style="display:none;">'
+          )
+        else:
+          raise ValueError(
+            "Found "
+            + value.strip()
+            + " in Comment.Special should only catch string that are #SHORTCUT, #EXPANSION, #ENDEXPANSION, #HIDDEN or #ENDHIDDEN"
+          )
+        # This sets up the label at the start of a new block with NODEFAULT or SHORTCUT
+        if ttype == Comment.Preproc:
+          if label != "" and label != act_label:
+            raise Exception(
+              "label for shortcut ("
+              + act_label
+              + ") doesn't match action label ("
+              + label
+              + ")"
+            )
+          elif label == "":
+            label = act_label
+      elif ttype == Generic:
+        # whatever in KEYWORD=whatever
+        if action == "INCLUDE" and shortcut_state == 1:
+          # special treatment for filename in INCLUDE FILE=filename
+          outfile.write(
+            "<a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+            + self.egname
+            + label
+            + "\");'>"
+            + value
+            + "</a>"
+          )
+        else:
+          # notice special treatment here because we want to find labels so we can show paths
+          inputs, nocomma = value.split(","), True
+          for inp in inputs:
+            islab, inpt = False, inp.strip()
+            for lab in all_labels:
+              if inpt.split(".")[0] == lab:
+                islab = True
+                break
+            if not nocomma:
+              outfile.write(",")
+            if islab:
+              outfile.write(
+                '<b name="' + self.egname + inpt.split(".")[0] + '">' + inp + "</b>"
+              )
+            # Deal with files
+            elif inp in self.auxinputs:
+              iff = open(inp, "r")
+              fcontent = iff.read()
+              iff.close()
+              # This does syntax highlighting on cpp files
+              if inp.split(".")[-1] == "cpp":
+                fcontent = highlight(fcontent, CppLexer(), HtmlFormatter())
+              nfiles = nfiles + 1
+              if len(self.auxinputlines) > 0:
+                shortversion, allines = "", fcontent.splitlines()
+                for n, ll in enumerate(self.auxinputlines):
+                  bounds = ll.split("-")
+                  start, end = int(bounds[0]), int(bounds[1])
+                  if start > len(allines):
+                    break
+                  if n > 0:
+                    shortversion += "...\n"
+                  for kk in range(start, end + 1):
+                    if kk <= len(allines):
+                      shortversion += allines[kk - 1] + "\n"
+                fcontent = shortversion
+              outfile.write(
+                '<div class="plumedtooltip">'
+                + inp
+                + '<div class="right"> Click <a onclick=\'openModal("'
+                + self.egname
+                + inp
+                + str(nfiles)
+                + "\")'>here</a> to see an extract from this file.<i></i></div></div>"
+              )
+              outfile.write(
+                '<div id="' + self.egname + inp + str(nfiles) + '" class="plumedmodal">'
+              )
+              outfile.write('  <div class="plumedmodal-content">')
+              outfile.write('<div class="plumedmodal-header">')
+              outfile.write(
+                '  <span class="close" onclick=\'closeModal("'
+                + self.egname
+                + inp
+                + str(nfiles)
+                + "\")'>&times;</span>"
+              )
+              outfile.write("  <h2>FILE: " + inp + "</h2>")
+              outfile.write("</div>")
+              outfile.write('<div class="plumedmodal-body">')
+              outfile.write("    <pre>" + fcontent + "</pre>")
+              outfile.write("</div>")
+              outfile.write("  </div>")
+              outfile.write("</div>")
+            # Deal with atom selections
+            elif "@" in inp:
+              tooltip, link = "", ""
+              # Deal with residue
+              if "-" in inp:
+                select, defs, residue = "", inp.split("-"), ""
+                if "_" in defs[1]:
+                  resp = defs[1].split("_")
+                  residue = "residue " + resp[1] + " in chain " + resp[0]
+                else:
+                  residue = "residue " + defs[1]
+                select = defs[0] + "-"
+                if select not in self.keyword_dict["groups"]:
+                  tooltip, link = (
+                    "the " + defs[0][1:] + " atom in " + residue,
+                    self.keyword_dict["groups"]["@protein"]["link"],
+                  )
+                else:
+                  tooltip, link = (
+                    self.keyword_dict["groups"][select]["description"] + " " + residue,
+                    self.keyword_dict["groups"][select]["link"],
+                  )
+              else:
+                select = inp.strip()
+                if select in self.keyword_dict["groups"]:
+                  tooltip, link = (
+                    self.keyword_dict["groups"][select]["description"],
+                    self.keyword_dict["groups"][select]["link"],
+                  )
+              if len(tooltip) > 0:
+                outfile.write(
+                  '<span class="plumedtooltip">'
+                  + inp
+                  + '<span class="right">'
+                  + tooltip
+                  + '. <a href="'
+                  + link
+                  + '">Click here</a> for more information. <i></i></span></span>'
+                )
+              else:
+                outfile.write(html.escape(inp))
+            else:
+              outfile.write(html.escape(inp))
+            nocomma = False
+      elif ttype == String or ttype == String.Double:
+        # Labels of actions
+        if not self.broken and action != "" and label != "" and label != value.strip():
+          raise Exception(
+            "label for "
+            + action
+            + " is not what is expected.  Is "
+            + label
+            + " should be "
+            + value.strip()
+          )
+        elif value.strip() == "plumed-runtime":
+          label = "plumed"
+        elif label == "":
+          label = html.escape(value.strip())
+        valtype = "mix"
+        if label in self.valuedict.keys():
+          valtype = "unset"
+          for key, ddd in self.valuedict[label].items():
+            if key == "action":
+              continue
+            elif valtype == "unset":
+              valtype = ddd["type"]
+            elif valtype != ddd["type"]:
+              valtype = "mix"
+        if shortcut_state == 1 and "shortcut_" + label in self.valuedict.keys():
+          outfile.write(
+            '<b name="'
+            + self.egname
+            + label
+            + '" onclick=\'showPath("'
+            + self.divname
+            + '","'
+            + self.egname
+            + label
+            + '","'
+            + self.egname
+            + label
+            + '_shortcut","'
+            + self.valcolors[valtype]
+            + "\")'>"
+            + value
+            + "</b>"
+          )
+          if label + "_shortcut" not in all_labels:
+            all_labels.add(label + "_shortcut")
+            self.writeValueInfo(
+              outfile,
+              label,
+              label + "_shortcut",
+              self.valuedict["shortcut_" + label],
+            )
+        else:
+          outfile.write(
+            '<b name="'
+            + self.egname
+            + label
+            + '" onclick=\'showPath("'
+            + self.divname
+            + '","'
+            + self.egname
+            + label
+            + '","'
+            + self.egname
+            + label
+            + '","'
+            + self.valcolors[valtype]
+            + "\")'>"
+            + value
+            + "</b>"
+          )
+          if label in self.valuedict.keys() and label not in all_labels:
+            all_labels.add(label)
+            self.writeValueInfo(outfile, label, label, self.valuedict[label])
+      elif ttype == Comment:
+        # Comments
+        outfile.write(
+          '<span style="color:blue" class="comment">' + html.escape(value) + "</span>"
+        )
+      elif ttype == Name.Attribute:
+        # KEYWORD in KEYWORD=whatever and FLAGS
+        keywords.append(value.strip().upper())
+        if notooltips:
+          outfile.write(value.strip())
+        else:
+          desc, mykey = "", value.strip().upper()
+          if action not in self.keyword_dict:
+            raise Exception("action " + action + " not present in keyword dictionary")
+          if "syntax" not in self.keyword_dict[action]:
+            raise Exception("syntax not present in documentation for " + action)
+          if (
+            mykey not in self.keyword_dict[action]["syntax"]
+            and value.strip() in self.keyword_dict[action]["syntax"]
+          ):
+            mykey = value.strip()
 
-                  if mykey=="--HELP" or mykey=="-H" : 
-                     mykey, desc = "--help/-h", self.keyword_dict[action]["syntax"]["--help/-h"]["description"] 
-                  elif mykey in self.keyword_dict[action]["syntax"] : 
-                     desc = self.keyword_dict[action]["syntax"][mykey]["description"].split('.')[0]
-                  else :
-                     # This deals with numbered keywords
-                     foundkey=False
-                     for kkkk in self.keyword_dict[action]["syntax"] :
-                         if kkkk=="output" or self.keyword_dict[action]["syntax"][kkkk]["multiple"]==0 : continue
-                         if kkkk in value.strip() : foundkey, mykey, desc = True, kkkk.upper(), self.keyword_dict[action]["syntax"][kkkk.upper()]["description"].split('.')[0]
-                     if not self.broken and not notooltips and not foundkey : 
-                        if self.hasload : foundkey, desc = True, 'There is a possibity that this action is not part of PLUMED and was included by using a LOAD command. This LOADing replaces one of the actions that is in PLUMED. You should thus be wary of the documentation in these tooltips and look at the cpp file that was loaded <a href="' + self.keyword_dict["LOAD"]["hyperlink"] + '" style="color:green">More details</a>'
-                        else : raise Exception("keyword " + value.strip().upper() + " is not in syntax for action " + action )
-                  if desc=="" and self.broken : outfile.write( value )
-                  else :
-                     if action not in self.keyword_dict : raise Exception("action " + action + " not present in keyword dictionary")
-                     if "actionlink" in self.keyword_dict[action]["syntax"][mykey].keys() and self.keyword_dict[action]["syntax"][mykey]["actionlink"]!="none" : 
-                        linkaction = self.keyword_dict[action]["syntax"][mykey]["actionlink"]
-                        desc = desc + ". Options for this keyword are explained in the documentation for <a href=\"" + self.keyword_dict[linkaction]["hyperlink"] + "\">" + linkaction + "</a>.";  
-                     outfile.write('<span class="plumedtooltip">' + value + '<span class="right">' + desc + '<i></i></span></span>')
-            elif ttype==Name.Constant :
-               # @replicas in special replica syntax
-               if value=="@replicas:" : 
-                  outfile.write('<span class="plumedtooltip">' + value + '<span class="right">This keyword specifies that different replicas have different values for this quantity.  See <a href="' + self.keyword_dict["replicalink"] +'">here for more details.</a><i></i></span></span>')
-               # Deal with external libraries doing atom selections
-               else :
-                  if value not in self.keyword_dict["groups"] : raise Exception("special group " + value + " not in special group dictionary")
-                  outfile.write('<span class="plumedtooltip">' + value + '<span class="right">' + self.keyword_dict["groups"][value]["description"] + '.  <a href="' + self.keyword_dict["groups"][value]["link"] + '">Click here</a> for more information. <i></i></span></span>');
-            elif ttype==Name.Decorator :
-               # Input files for command line tools
-               outfile.write('<span class="plumedtooltip">' + value + '<span class="right"> This is the input file for the calculation.<i></i></span></span>')
-            elif ttype==Name.Entity :
-               # Direct out for command line tools
-               outfile.write('<span class="plumedtooltip">' + value + '<span class="right"> What is printed on standard output is directed to a file with this name.<i></i></span></span>')
-            elif ttype==Keyword :
-               action, notooltips = value.strip(), False
-               if action not in self.keyword_dict :
-                  action = value.upper()
-               # Name of action
-               if action not in self.keyword_dict : 
-                  if self.hasload or self.broken : notooltips = True
-                  else : raise Exception("no action " + action + " in dictionary")
-               else :
-                  # Store name of action in set that contains all action names
-                  self.actions.add(action)
-               if default_state!=0 or shortcut_state==1 : 
-                  if label!="" and label!=act_label : raise Exception("mismatched label and act_label for shortcut/default label=" + label + " act_label=" + act_label ) 
-               if notooltips :
-                    outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">This action is not part of PLUMED and was included by using a LOAD command <a href="' + self.keyword_dict["LOAD"]["hyperlink"] + '" style="color:green">More details</a><i></i></span></span>') 
-               elif shortcut_state==1 and default_state==1 :
-                    outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">' + self.keyword_dict[action]["description"] + ' This action is <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + label + '");\'>a shortcut</a> and it has <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + "def" + act_label + '");\'>hidden defaults</a>. <a href="' + self.keyword_dict[action]["hyperlink"] + '">More details</a><i></i></span></span>') 
-               elif shortcut_state==1 and default_state==2 :
-                    outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">' + self.keyword_dict[action]["description"] + ' This action is <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + act_label + '");\'>a shortcut</a> and uses the <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + "def" + act_label + '");\'>defaults shown here</a>. <a href="' + self.keyword_dict[action]["hyperlink"] + '">More details</a><i></i></span></span>')
-               elif default_state==1 :
-                    outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">' + self.keyword_dict[action]["description"] + ' This action has <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + "def" + act_label + '");\'>hidden defaults</a>. <a href="' + self.keyword_dict[action]["hyperlink"] + '">More details</a><i></i></span></span>')
-               elif default_state==2 :
-                    outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">' + self.keyword_dict[action]["description"] + ' This action uses the <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + "def" + act_label + '");\'>defaults shown here</a>. <a href="' + self.keyword_dict[action]["hyperlink"] + '">More details</a><i></i></span></span>')
-               elif shortcut_state==1 :
-                     if action=="INCLUDE" : outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">' + self.keyword_dict[action]["description"] + ' <a href="' + self.keyword_dict[action]["hyperlink"] + '">More details</a>. Show <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + act_label + '");\'>included file</a><i></i></span></span>')
-                     else : outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">' + self.keyword_dict[action]["description"] + ' This action is <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("' + self.egname + act_label + '");\'>a shortcut</a>. <a href="' + self.keyword_dict[action]["hyperlink"] + '">More details</a><i></i></span></span>')
-               else :
-                     outfile.write('<span class="plumedtooltip" style="color:green">' + value.strip() + '<span class="right">'+ self.keyword_dict[action]["description"] + ' <a href="' + self.keyword_dict[action]["hyperlink"] + '" style="color:green">More details</a><i></i></span></span>')
-        # Check if there is stuff to output for the last action in the file
-        if action==self.checkaction : 
-           self.storeKeywordsForCheckAction( keywords )
-        if len(label)>0 and label not in all_labels and label not in self.valuedict.keys() :
-           all_labels.add( label )
-           if action in self.keyword_dict and "output" in self.keyword_dict[action]["syntax"] : self.writeValuesData( outfile, action, label, keywords, self.keyword_dict[action]["syntax"]["output"] )
-           else : 
-              outfile.write('<span style="display:none;" id="' + self.egname + label + r'">')
-              outfile.write('The ' + action + ' action with label <b>' + label + '</b> calculates something')
-              outfile.write('</span>')
-        outfile.write('</pre>')
-
-    def writeValuesData( self, outfile, action, label, keywords, outdict ) :
-        # Some header stuff 
+          if mykey == "--HELP" or mykey == "-H":
+            mykey, desc = (
+              "--help/-h",
+              self.keyword_dict[action]["syntax"]["--help/-h"]["description"],
+            )
+          elif mykey in self.keyword_dict[action]["syntax"]:
+            desc = self.keyword_dict[action]["syntax"][mykey]["description"].split(".")[
+              0
+            ]
+          else:
+            # This deals with numbered keywords
+            foundkey = False
+            for kkkk in self.keyword_dict[action]["syntax"]:
+              if (
+                kkkk == "output"
+                or self.keyword_dict[action]["syntax"][kkkk]["multiple"] == 0
+              ):
+                continue
+              if kkkk in value.strip():
+                foundkey, mykey, desc = (
+                  True,
+                  kkkk.upper(),
+                  self.keyword_dict[action]["syntax"][kkkk.upper()][
+                    "description"
+                  ].split(".")[0],
+                )
+            if not self.broken and not notooltips and not foundkey:
+              if self.hasload:
+                foundkey, desc = (
+                  True,
+                  'There is a possibity that this action is not part of PLUMED and was included by using a LOAD command. This LOADing replaces one of the actions that is in PLUMED. You should thus be wary of the documentation in these tooltips and look at the cpp file that was loaded <a href="'
+                  + self.keyword_dict["LOAD"]["hyperlink"]
+                  + '" style="color:green">More details</a>',
+                )
+              else:
+                raise Exception(
+                  "keyword "
+                  + value.strip().upper()
+                  + " is not in syntax for action "
+                  + action
+                )
+          if desc == "" and self.broken:
+            outfile.write(value)
+          else:
+            if action not in self.keyword_dict:
+              raise Exception("action " + action + " not present in keyword dictionary")
+            if (
+              "actionlink" in self.keyword_dict[action]["syntax"][mykey].keys()
+              and self.keyword_dict[action]["syntax"][mykey]["actionlink"] != "none"
+            ):
+              linkaction = self.keyword_dict[action]["syntax"][mykey]["actionlink"]
+              desc = (
+                desc
+                + '. Options for this keyword are explained in the documentation for <a href="'
+                + self.keyword_dict[linkaction]["hyperlink"]
+                + '">'
+                + linkaction
+                + "</a>."
+              )
+            outfile.write(
+              '<span class="plumedtooltip">'
+              + value
+              + '<span class="right">'
+              + desc
+              + "<i></i></span></span>"
+            )
+      elif ttype == Name.Constant:
+        # @replicas in special replica syntax
+        if value == "@replicas:":
+          outfile.write(
+            '<span class="plumedtooltip">'
+            + value
+            + '<span class="right">This keyword specifies that different replicas have different values for this quantity.  See <a href="'
+            + self.keyword_dict["replicalink"]
+            + '">here for more details.</a><i></i></span></span>'
+          )
+        # Deal with external libraries doing atom selections
+        else:
+          if value not in self.keyword_dict["groups"]:
+            raise Exception(
+              "special group " + value + " not in special group dictionary"
+            )
+          outfile.write(
+            '<span class="plumedtooltip">'
+            + value
+            + '<span class="right">'
+            + self.keyword_dict["groups"][value]["description"]
+            + '.  <a href="'
+            + self.keyword_dict["groups"][value]["link"]
+            + '">Click here</a> for more information. <i></i></span></span>'
+          )
+      elif ttype == Name.Decorator:
+        # Input files for command line tools
+        outfile.write(
+          '<span class="plumedtooltip">'
+          + value
+          + '<span class="right"> This is the input file for the calculation.<i></i></span></span>'
+        )
+      elif ttype == Name.Entity:
+        # Direct out for command line tools
+        outfile.write(
+          '<span class="plumedtooltip">'
+          + value
+          + '<span class="right"> What is printed on standard output is directed to a file with this name.<i></i></span></span>'
+        )
+      elif ttype == Keyword:
+        action, notooltips = value.strip(), False
+        if action not in self.keyword_dict:
+          action = value.upper()
+        # Name of action
+        if action not in self.keyword_dict:
+          if self.hasload or self.broken:
+            notooltips = True
+          else:
+            raise Exception("no action " + action + " in dictionary")
+        else:
+          # Store name of action in set that contains all action names
+          self.actions.add(action)
+        if default_state != 0 or shortcut_state == 1:
+          if label != "" and label != act_label:
+            raise Exception(
+              "mismatched label and act_label for shortcut/default label="
+              + label
+              + " act_label="
+              + act_label
+            )
+        if notooltips:
+          outfile.write(
+            '<span class="plumedtooltip" style="color:green">'
+            + value.strip()
+            + '<span class="right">This action is not part of PLUMED and was included by using a LOAD command <a href="'
+            + self.keyword_dict["LOAD"]["hyperlink"]
+            + '" style="color:green">More details</a><i></i></span></span>'
+          )
+        elif shortcut_state == 1 and default_state == 1:
+          outfile.write(
+            '<span class="plumedtooltip" style="color:green">'
+            + value.strip()
+            + '<span class="right">'
+            + self.keyword_dict[action]["description"]
+            + " This action is <a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+            + self.egname
+            + label
+            + "\");'>a shortcut</a> and it has <a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+            + self.egname
+            + "def"
+            + act_label
+            + '");\'>hidden defaults</a>. <a href="'
+            + self.keyword_dict[action]["hyperlink"]
+            + '">More details</a><i></i></span></span>'
+          )
+        elif shortcut_state == 1 and default_state == 2:
+          outfile.write(
+            '<span class="plumedtooltip" style="color:green">'
+            + value.strip()
+            + '<span class="right">'
+            + self.keyword_dict[action]["description"]
+            + " This action is <a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+            + self.egname
+            + act_label
+            + "\");'>a shortcut</a> and uses the <a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+            + self.egname
+            + "def"
+            + act_label
+            + '");\'>defaults shown here</a>. <a href="'
+            + self.keyword_dict[action]["hyperlink"]
+            + '">More details</a><i></i></span></span>'
+          )
+        elif default_state == 1:
+          outfile.write(
+            '<span class="plumedtooltip" style="color:green">'
+            + value.strip()
+            + '<span class="right">'
+            + self.keyword_dict[action]["description"]
+            + " This action has <a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+            + self.egname
+            + "def"
+            + act_label
+            + '");\'>hidden defaults</a>. <a href="'
+            + self.keyword_dict[action]["hyperlink"]
+            + '">More details</a><i></i></span></span>'
+          )
+        elif default_state == 2:
+          outfile.write(
+            '<span class="plumedtooltip" style="color:green">'
+            + value.strip()
+            + '<span class="right">'
+            + self.keyword_dict[action]["description"]
+            + " This action uses the <a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+            + self.egname
+            + "def"
+            + act_label
+            + '");\'>defaults shown here</a>. <a href="'
+            + self.keyword_dict[action]["hyperlink"]
+            + '">More details</a><i></i></span></span>'
+          )
+        elif shortcut_state == 1:
+          if action == "INCLUDE":
+            outfile.write(
+              '<span class="plumedtooltip" style="color:green">'
+              + value.strip()
+              + '<span class="right">'
+              + self.keyword_dict[action]["description"]
+              + ' <a href="'
+              + self.keyword_dict[action]["hyperlink"]
+              + '">More details</a>. Show <a class="toggler" href=\'javascript:;\' onclick=\'toggleDisplay("'
+              + self.egname
+              + act_label
+              + "\");'>included file</a><i></i></span></span>"
+            )
+          else:
+            outfile.write(
+              '<span class="plumedtooltip" style="color:green">'
+              + value.strip()
+              + '<span class="right">'
+              + self.keyword_dict[action]["description"]
+              + " This action is <a class=\"toggler\" href='javascript:;' onclick='toggleDisplay(\""
+              + self.egname
+              + act_label
+              + '");\'>a shortcut</a>. <a href="'
+              + self.keyword_dict[action]["hyperlink"]
+              + '">More details</a><i></i></span></span>'
+            )
+        else:
+          outfile.write(
+            '<span class="plumedtooltip" style="color:green">'
+            + value.strip()
+            + '<span class="right">'
+            + self.keyword_dict[action]["description"]
+            + ' <a href="'
+            + self.keyword_dict[action]["hyperlink"]
+            + '" style="color:green">More details</a><i></i></span></span>'
+          )
+    # Check if there is stuff to output for the last action in the file
+    if action == self.checkaction:
+      self.storeKeywordsForCheckAction(keywords)
+    if (
+      len(label) > 0 and label not in all_labels and label not in self.valuedict.keys()
+    ):
+      all_labels.add(label)
+      if (
+        action in self.keyword_dict and "output" in self.keyword_dict[action]["syntax"]
+      ):
+        self.writeValuesData(
+          outfile,
+          action,
+          label,
+          keywords,
+          self.keyword_dict[action]["syntax"]["output"],
+        )
+      else:
         outfile.write('<span style="display:none;" id="' + self.egname + label + r'">')
-        outfile.write('The ' + action + ' action with label <b>' + label + '</b>')
-        # Check for components
-        found_flags = False
-        for key, value in outdict.items() :
-            for flag in keywords :
-                if flag==value["flag"] or value["flag"]=="default" : found_flags=True
-        # Output string for value
-        if not found_flags and "value" in outdict : 
-            outfile.write(' calculates ' + outdict["value"]["description"] )
-        # Output table containing descriptions of all components
-        else :
-            outfile.write(' calculates the following quantities:')
-            outfile.write('<table  align="center" frame="void" width="95%" cellpadding="5%">')
-            outfile.write('<tr><td width="5%"><b> Quantity </b>  </td><td><b> Description </b> </td></tr>')    
-            for key, value in outdict.items() :
-                present = False 
-                for flag in keywords : 
-                    if flag==value["flag"] : present=True
-                if present or value["flag"]=="default" : outfile.write('<tr><td width="5%">' + label + "." + key + '</td><td>' + value["description"] + '</td></tr>')
-            outfile.write('</table>')
-        outfile.write('</span>')
+        outfile.write(
+          "The "
+          + action
+          + " action with label <b>"
+          + label
+          + "</b> calculates something"
+        )
+        outfile.write("</span>")
+    outfile.write("</pre>")
 
-    def writeValueInfo( self, outfile, label, span_label, valinfo ) :
-        # Some header stuff 
-        outfile.write('<span style="display:none;" id="' + self.egname + span_label + r'">')
-        outfile.write('The ' + valinfo["action"] + ' action with label <b>' + label + '</b>')
-        outfile.write(' calculates the following quantities:')
-        outfile.write('<table  align="center" frame="void" width="95%" cellpadding="5%">')
-        outfile.write('<tr><td width="5%"><b> Quantity </b>  </td><td width="5%"><b> Type </b>  </td><td><b> Description </b> </td></tr>')
-        for key, value in valinfo.items() :
-            if key=="action" : continue
-            outfile.write('<tr><td width="5%">' + key + '</td><td width="5%"><font color="' + self.valcolors[value["type"]] +'">' + value["type"] + '</font></td><td>' + value["description"] + '</td></tr>')
-        outfile.write('</table>') 
-        outfile.write('</span>')
+  def writeValuesData(self, outfile, action, label, keywords, outdict):
+    # Some header stuff
+    outfile.write('<span style="display:none;" id="' + self.egname + label + r'">')
+    outfile.write("The " + action + " action with label <b>" + label + "</b>")
+    # Check for components
+    found_flags = False
+    for key, value in outdict.items():
+      for flag in keywords:
+        if flag == value["flag"] or value["flag"] == "default":
+          found_flags = True
+    # Output string for value
+    if not found_flags and "value" in outdict:
+      outfile.write(" calculates " + outdict["value"]["description"])
+    # Output table containing descriptions of all components
+    else:
+      outfile.write(" calculates the following quantities:")
+      outfile.write('<table  align="center" frame="void" width="95%" cellpadding="5%">')
+      outfile.write(
+        '<tr><td width="5%"><b> Quantity </b>  </td><td><b> Description </b> </td></tr>'
+      )
+      for key, value in outdict.items():
+        present = False
+        for flag in keywords:
+          if flag == value["flag"]:
+            present = True
+        if present or value["flag"] == "default":
+          outfile.write(
+            '<tr><td width="5%">'
+            + label
+            + "."
+            + key
+            + "</td><td>"
+            + value["description"]
+            + "</td></tr>"
+          )
+      outfile.write("</table>")
+    outfile.write("</span>")
 
-    def getCheckActionKeywords( self ) :
-        return self.checkaction_keywords 
+  def writeValueInfo(self, outfile, label, span_label, valinfo):
+    # Some header stuff
+    outfile.write('<span style="display:none;" id="' + self.egname + span_label + r'">')
+    outfile.write(
+      "The " + valinfo["action"] + " action with label <b>" + label + "</b>"
+    )
+    outfile.write(" calculates the following quantities:")
+    outfile.write('<table  align="center" frame="void" width="95%" cellpadding="5%">')
+    outfile.write(
+      '<tr><td width="5%"><b> Quantity </b>  </td><td width="5%"><b> Type </b>  </td><td><b> Description </b> </td></tr>'
+    )
+    for key, value in valinfo.items():
+      if key == "action":
+        continue
+      outfile.write(
+        '<tr><td width="5%">'
+        + key
+        + '</td><td width="5%"><font color="'
+        + self.valcolors[value["type"]]
+        + '">'
+        + value["type"]
+        + "</font></td><td>"
+        + value["description"]
+        + "</td></tr>"
+      )
+    outfile.write("</table>")
+    outfile.write("</span>")
 
-    def storeKeywordsForCheckAction( self, keywords ) :
-        for key in keywords :
-            if key in self.keyword_dict[self.checkaction]["syntax"] : 
-               self.checkaction_keywords.add( key )
-            else : 
-               # This makes sure we find numbered keywords
-               for kkkk in self.keyword_dict[self.checkaction]["syntax"] :
-                   if kkkk=="output" or self.keyword_dict[self.checkaction]["syntax"][kkkk]["multiple"]==0 : continue
-                   if kkkk in key : self.checkaction_keywords.add( kkkk )
- 
+  def getCheckActionKeywords(self):
+    return self.checkaction_keywords
+
+  def storeKeywordsForCheckAction(self, keywords):
+    for key in keywords:
+      if key in self.keyword_dict[self.checkaction]["syntax"]:
+        self.checkaction_keywords.add(key)
+      else:
+        # This makes sure we find numbered keywords
+        for kkkk in self.keyword_dict[self.checkaction]["syntax"]:
+          if (
+            kkkk == "output"
+            or self.keyword_dict[self.checkaction]["syntax"][kkkk]["multiple"] == 0
+          ):
+            continue
+          if kkkk in key:
+            self.checkaction_keywords.add(kkkk)

--- a/src/PlumedToHTML/PlumedLexer.py
+++ b/src/PlumedToHTML/PlumedLexer.py
@@ -1,93 +1,125 @@
 from pygments.lexer import RegexLexer, bygroups, include
 from pygments.token import Text, Comment, Literal, Keyword, Name, Generic, String
 
-class PlumedLexer(RegexLexer):
-    name = 'plumed'
-    aliases = ['plumed']
-    filenames = ['*.plmd']
 
-    tokens = {
-        'defaults' : [
-            # Deals with blank space
-            (r'\s+$', Text),
-            # Deals with all comments
-            (r'#.*$', Comment),
-            # Deals with incomplete inputs 
-            (r'(__FILL__)(=)(\S+\b)', bygroups(Literal, Text, Generic)),
-            (r'(\w+)(=)(__FILL__)', bygroups(Name.Attribute, Text, Literal)),
-            (r'__FILL__', Literal),  
-            # Find LABEL=lab
-            (r'([Ll][Aa][Bb][Ee][Ll])(=)(\S+\b)', bygroups(Name.Attribute, Text, String.Double)),
-            # Find special replica syntax with fill
-            (r'(\w+)(=)(@\S+:)(__FILL__)', bygroups(Name.Attribute, Text, Name.Constant, Literal)), 
-            # Find special replica syntax with brackets around replica command
-            (r'(?s)(\w+)(=\{)(@\S+:)(\{.*?\})(\})', bygroups(Name.Attribute, Text, Name.Constant, Generic, Text)),
-            # Find special repliica syntax with multiple brackets
-            (r'(?s)(\w+)(=)(@\S+:)(\{\s*\{.*?\}\s*\})', bygroups(Name.Attribute, Text, Name.Constant, Generic)), 
-            # Find special replica syntax with brackets
-            (r'(?s)(\w+)(=)(@\S+:)(\{.*?\})', bygroups(Name.Attribute, Text, Name.Constant, Generic)),  
-            # Find special replica syntax without brackets
-            (r'(\w+)(=)(@\S+:)(\S+\b)', bygroups(Name.Attribute, Text, Name.Constant, Generic)),
-            # Find KEYWORD with {} brackets around value
-            (r'(?s)(\w+)(=)(\{.*?\})', bygroups(Name.Attribute, Text, Generic)),
-            # Find KEYWORD=whatever with comment immediately after end of whatever
-            (r'(\w+)(=)(\S+)(#.*$)', bygroups(Name.Attribute, Text, Generic, Comment)),
-            # Find KEYWORD=whatever 
-            (r'(\w+)(=)(\S+)(\s*)', bygroups(Name.Attribute, Text, Generic, Text))
-         ],
-        'root': [
-            # Deals with blank lines
-            (r'^\n', Text.Whitespace),
-            # Find comment reversion stuff
-            (r'(^# The command:\n)(#.+\n)(# ensures PLUMED loads the contents of the file called .+$)',bygroups(Comment, Comment.Hashbang, Comment)),
-            # And stuff for long versions of shortcuts
-            (r'(^# PLUMED interprets the command:\n)(#.+$)', bygroups(Comment, Comment.Hashbang)),
-            # Find ENDPLUMED and set everything after it to a comment
-            (r'(?s)(^\s*)([Ee][Nn][Dd][Pp][Ll][Uu][Mm][Ee][Dd])(.*\Z)', bygroups(Text, Keyword, Comment)),
-            # Find the start of shortcuts
-            (r'#SHORTCUT.*?\r?\n',Comment.Preproc),
-            # Find the start of a shortcut with a nested default
-            (r'#NODEFAULT.*?\r?\n',Comment.Special),
-            # Find the start of a default section
-            (r'#DEFAULT.*?\r?\n',Comment.Special),
-            # Find the end of a default section
-            (r'#ENDDEFAULT.*?\r?\n',Comment.Special),
-            # Find the middle of shortcuts
-            (r'#EXPANSION.*?\r?\n',Comment.Special),
-            # Find the end of shortcuts
-            (r'#ENDEXPANSION.*?\r?\n',Comment.Special),
-            # Find the start of a hidden section
-            (r'#HIDDEN\s*\n',Comment.Special),
-            # Fidn the end of a hidden section
-            (r'#ENDHIDDEN\s*\n',Comment.Special),
-            # Find vimsyntax expression
-            (r'#\s*vim:\s*ft=plumed',Literal),
-            # Include all the default stuff
-            include('defaults'), 
-            # Find label: __FILL__
-            (r'(.+)(:\s+)(__FILL__)', bygroups(String, Text, Literal)),
-            # Find label: ACTION
-            (r'([^#^\n]+?)(:\s+)([^\s#]+\b)', bygroups(String, Text, Keyword)),
-            # Find label: ... \n ACTION  
-            (r'(.+)(:\s+\.\.\.\s*$\s*)(\S+\b)', bygroups(String, Text, Keyword), 'continuation'),
-            # Find ... for start of continuation
-            (r'\.\.\.', Text, 'continuation'),
-            # Find ACTION at start of line
-            (r'^\s*\w+\b',Keyword),
-            # Find FLAG anywhere on line
-            (r'\w+\b',Name.Attribute),
-            # Find any left over white space
-            (r'\s+',Text)
-        ],
-        'continuation' : [
-            include('defaults'),
-            # Find FLAG which can now be anywhere on line or at start of line in continuation
-            (r'\w+\b', Name.Attribute),
-            # Find any left over white space 
-            (r'\s+', Text),
-            # Find ... ACTION as end of continuation
-            (r'(\.\.\.)(.+$)', bygroups(Text, Text), '#pop'),
-            # Find ... as end of continuation
-            (r'\.\.\.', Text, '#pop')
-        ]
-    }
+class PlumedLexer(RegexLexer):
+  name = "plumed"
+  aliases = ["plumed"]
+  filenames = ["*.plmd"]
+
+  tokens = {
+    "defaults": [
+      # Deals with blank space
+      (r"\s+$", Text),
+      # Deals with all comments
+      (r"#.*$", Comment),
+      # Deals with incomplete inputs
+      (r"(__FILL__)(=)(\S+\b)", bygroups(Literal, Text, Generic)),
+      (r"(\w+)(=)(__FILL__)", bygroups(Name.Attribute, Text, Literal)),
+      (r"__FILL__", Literal),
+      # Find LABEL=lab
+      (
+        r"([Ll][Aa][Bb][Ee][Ll])(=)(\S+\b)",
+        bygroups(Name.Attribute, Text, String.Double),
+      ),
+      # Find special replica syntax with fill
+      (
+        r"(\w+)(=)(@\S+:)(__FILL__)",
+        bygroups(Name.Attribute, Text, Name.Constant, Literal),
+      ),
+      # Find special replica syntax with brackets around replica command
+      (
+        r"(?s)(\w+)(=\{)(@\S+:)(\{.*?\})(\})",
+        bygroups(Name.Attribute, Text, Name.Constant, Generic, Text),
+      ),
+      # Find special repliica syntax with multiple brackets
+      (
+        r"(?s)(\w+)(=)(@\S+:)(\{\s*\{.*?\}\s*\})",
+        bygroups(Name.Attribute, Text, Name.Constant, Generic),
+      ),
+      # Find special replica syntax with brackets
+      (
+        r"(?s)(\w+)(=)(@\S+:)(\{.*?\})",
+        bygroups(Name.Attribute, Text, Name.Constant, Generic),
+      ),
+      # Find special replica syntax without brackets
+      (
+        r"(\w+)(=)(@\S+:)(\S+\b)",
+        bygroups(Name.Attribute, Text, Name.Constant, Generic),
+      ),
+      # Find KEYWORD with {} brackets around value
+      (r"(?s)(\w+)(=)(\{.*?\})", bygroups(Name.Attribute, Text, Generic)),
+      # Find KEYWORD=whatever with comment immediately after end of whatever
+      (r"(\w+)(=)(\S+)(#.*$)", bygroups(Name.Attribute, Text, Generic, Comment)),
+      # Find KEYWORD=whatever
+      (r"(\w+)(=)(\S+)(\s*)", bygroups(Name.Attribute, Text, Generic, Text)),
+    ],
+    "root": [
+      # Deals with blank lines
+      (r"^\n", Text.Whitespace),
+      # Find comment reversion stuff
+      (
+        r"(^# The command:\n)(#.+\n)(# ensures PLUMED loads the contents of the file called .+$)",
+        bygroups(Comment, Comment.Hashbang, Comment),
+      ),
+      # And stuff for long versions of shortcuts
+      (
+        r"(^# PLUMED interprets the command:\n)(#.+$)",
+        bygroups(Comment, Comment.Hashbang),
+      ),
+      # Find ENDPLUMED and set everything after it to a comment
+      (
+        r"(?s)(^\s*)([Ee][Nn][Dd][Pp][Ll][Uu][Mm][Ee][Dd])(.*\Z)",
+        bygroups(Text, Keyword, Comment),
+      ),
+      # Find the start of shortcuts
+      (r"#SHORTCUT.*?\r?\n", Comment.Preproc),
+      # Find the start of a shortcut with a nested default
+      (r"#NODEFAULT.*?\r?\n", Comment.Special),
+      # Find the start of a default section
+      (r"#DEFAULT.*?\r?\n", Comment.Special),
+      # Find the end of a default section
+      (r"#ENDDEFAULT.*?\r?\n", Comment.Special),
+      # Find the middle of shortcuts
+      (r"#EXPANSION.*?\r?\n", Comment.Special),
+      # Find the end of shortcuts
+      (r"#ENDEXPANSION.*?\r?\n", Comment.Special),
+      # Find the start of a hidden section
+      (r"#HIDDEN\s*\n", Comment.Special),
+      # Fidn the end of a hidden section
+      (r"#ENDHIDDEN\s*\n", Comment.Special),
+      # Find vimsyntax expression
+      (r"#\s*vim:\s*ft=plumed", Literal),
+      # Include all the default stuff
+      include("defaults"),
+      # Find label: __FILL__
+      (r"(.+)(:\s+)(__FILL__)", bygroups(String, Text, Literal)),
+      # Find label: ACTION
+      (r"([^#^\n]+?)(:\s+)([^\s#]+\b)", bygroups(String, Text, Keyword)),
+      # Find label: ... \n ACTION
+      (
+        r"(.+)(:\s+\.\.\.\s*$\s*)(\S+\b)",
+        bygroups(String, Text, Keyword),
+        "continuation",
+      ),
+      # Find ... for start of continuation
+      (r"\.\.\.", Text, "continuation"),
+      # Find ACTION at start of line
+      (r"^\s*\w+\b", Keyword),
+      # Find FLAG anywhere on line
+      (r"\w+\b", Name.Attribute),
+      # Find any left over white space
+      (r"\s+", Text),
+    ],
+    "continuation": [
+      include("defaults"),
+      # Find FLAG which can now be anywhere on line or at start of line in continuation
+      (r"\w+\b", Name.Attribute),
+      # Find any left over white space
+      (r"\s+", Text),
+      # Find ... ACTION as end of continuation
+      (r"(\.\.\.)(.+$)", bygroups(Text, Text), "#pop"),
+      # Find ... as end of continuation
+      (r"\.\.\.", Text, "#pop"),
+    ],
+  }

--- a/src/PlumedToHTML/PlumedToHTML.py
+++ b/src/PlumedToHTML/PlumedToHTML.py
@@ -1,4 +1,4 @@
-import subprocess 
+import subprocess
 import os
 import re
 import json
@@ -12,826 +12,1216 @@ from bs4 import BeautifulSoup
 from contextlib import contextmanager
 from pygments import highlight
 from pygments.lexers import load_lexer_from_file
-from pygments.formatters import load_formatter_from_file 
-# Uncomment this line if it is required for tests  
-#from pygments.formatters import HtmlFormatter
+from pygments.formatters import load_formatter_from_file
+# Uncomment this line if it is required for tests
+# from pygments.formatters import HtmlFormatter
+
 
 def zip(path):
-    """ Zip a path removing the original file """
-    with zipfile.ZipFile(path + ".zip", "w") as f_out:
-        f_out.write(path)
-    os.remove(path)
+  """Zip a path removing the original file"""
+  with zipfile.ZipFile(path + ".zip", "w") as f_out:
+    f_out.write(path)
+  os.remove(path)
+
 
 @contextmanager
 def cd(newdir):
-    prevdir = os.getcwd()
-    os.chdir(os.path.expanduser(newdir))
+  prevdir = os.getcwd()
+  os.chdir(os.path.expanduser(newdir))
+  try:
+    yield
+  finally:
+    os.chdir(prevdir)
+
+
+def getPlumedSyntax(plumedexe):
+  """
+  Get the plumed syntax information from the syntax.json file
+
+  This function reurns a dictionary that contains all the information on the plumed syntax that was read in from the
+  syntax.json file.
+
+  Keyword arguments:
+  plumedexe -- The plumed executibles that were used.  The last one is the one whose syntax.json file we retrieve
+  """
+  cmd = [plumedexe[-1], "info", "--root"]
+  plumed_info = subprocess.run(cmd, capture_output=True, text=True)
+  keyfile = plumed_info.stdout.strip() + "/json/syntax.json"
+  with open(keyfile) as f:
     try:
-        yield
-    finally:
-        os.chdir(prevdir)
+      keyword_dict = json.load(f)
+    except ValueError as ve:
+      raise Exception(f"The file {f} contains invalid json") from ve
+  return keyword_dict
 
-def getPlumedSyntax( plumedexe ) :
-    """
-       Get the plumed syntax information from the syntax.json file
 
-       This function reurns a dictionary that contains all the information on the plumed syntax that was read in from the 
-       syntax.json file.
+def test_and_get_html(inpt, name, actions=set({}), test_plumed_kwargs={}):
+  """
+  Test if the plumed input is broken and generate the html syntax
 
-       Keyword arguments:
-       plumedexe -- The plumed executibles that were used.  The last one is the one whose syntax.json file we retrieve
-    """
-    cmd = [plumedexe[-1], 'info', '--root']
-    plumed_info = subprocess.run(cmd, capture_output=True, text=True )
-    keyfile = plumed_info.stdout.strip() + "/json/syntax.json"
-    with open(keyfile) as f :
-        try:
-           keyword_dict = json.load(f)
-        except ValueError as ve:
-           raise InvalidJSONError(ve)
-    return keyword_dict  
+  This function wraps test_plumed and get_html
 
-def test_and_get_html( inpt, name, actions=set({}), test_plumed_kwargs={}) :
-    """
-        Test if the plumed input is broken and generate the html syntax
+  Keyword arguments:
+  inpt -- A string containing the PLUMED input
+  name -- The name to use for this input in the html
+  actions -- Set that is filled with the actions that were used in this input
+  """
+  # Check if this is to be included by another input
+  filename, keepfile = name + ".dat", False
+  for line in inpt.splitlines():
+    if "#SETTINGS" in line:
+      for word in line.split():
+        if "FILENAME=" in word:
+          filename, keepfile = word.replace("FILENAME=", ""), True
+  # Manage incomplete inputs
+  test_inpt, incomplete = manage_incomplete_inputs(inpt)
+  # Write the plumed input to a file
+  iff = open(filename, "w+")
+  iff.write(test_inpt + "\n")
+  iff.close()
+  # Now do the test
+  broken = test_plumed(
+    "plumed", filename, header="", printjson=True, **test_plumed_kwargs
+  )
+  # Retrieve the html that is output by plumed
+  html = get_html(
+    inpt, filename, filename, ("master",), (broken,), ("plumed",), actions=actions
+  )
+  # Remove the tempory files that we created
+  if not keepfile:
+    os.remove(filename)
 
-        This function wraps test_plumed and get_html
+  return html
 
-        Keyword arguments:
-        inpt -- A string containing the PLUMED input
-        name -- The name to use for this input in the html
-        actions -- Set that is filled with the actions that were used in this input
-    """
-    # Check if this is to be included by another input
-    filename, keepfile = name + ".dat", False
-    for line in inpt.splitlines() :
-        if "#SETTINGS" in line :
-           for word in line.split() :
-               if "FILENAME=" in word : filename, keepfile = word.replace("FILENAME=",""), True
-    # Manage incomplete inputs
-    test_inpt, incomplete = manage_incomplete_inputs( inpt )
-    # Write the plumed input to a file
-    iff = open( filename, "w+")
-    iff.write(test_inpt + "\n")
-    iff.close()
-    # Now do the test
-    broken = test_plumed( "plumed", filename, header="", printjson=True, **test_plumed_kwargs)
-    # Retrieve the html that is output by plumed
-    html = get_html( inpt, filename, filename, ("master",), (broken,), ("plumed",), actions=actions )
-    # Remove the tempory files that we created
-    if not keepfile : os.remove(filename)
 
-    return html
+def test_plumed(
+  executible,
+  filename,
+  header="",
+  printjson=False,
+  jsondir="./",
+  cmdTimeout: "None|float" = None,
+  ghmarkdown=True,
+):
+  """
+  Test if plumed can parse this input file
 
-def test_plumed( executible, filename, header="", printjson=False, jsondir="./", cmdTimeout:"None|float"=None, ghmarkdown=True ) :
-    """
-        Test if plumed can parse this input file
+  This function can be used to test if PLUMED can parse an input file.  It calls plumed using subprocess
 
-        This function can be used to test if PLUMED can parse an input file.  It calls plumed using subprocess
-
-        Keyword arguments:
-        executible   -- A string that contains the command for running plumed
-        filename     -- A string that contains the name of the plumed input file to parse
-        header       -- A string to put at the top of the error page that is output
-        printjson    -- Set true if you want to used plumed to print the files containing the expansions of shortcuts and the value dictionary 
-        jsondir      -- The directory in which to output the files containing the expansions of the shortcuts and the value dictionaries
-        cmdTimeout   -- Set the timeout for the plumed test 
-    """
-    # Get the information for running the code
-    run_folder = str(pathlib.PurePosixPath(filename).parent)
+  Keyword arguments:
+  executible   -- A string that contains the command for running plumed
+  filename     -- A string that contains the name of the plumed input file to parse
+  header       -- A string to put at the top of the error page that is output
+  printjson    -- Set true if you want to used plumed to print the files containing the expansions of shortcuts and the value dictionary
+  jsondir      -- The directory in which to output the files containing the expansions of the shortcuts and the value dictionaries
+  cmdTimeout   -- Set the timeout for the plumed test
+  """
+  # Get the information for running the code
+  run_folder = str(pathlib.PurePosixPath(filename).parent)
+  plumed_file = os.path.basename(filename)
+  # Read in the plumed inpt
+  nreplicas, natoms, ifile = 1, 100000, open(filename)
+  for line in ifile.readlines():
+    if "#SETTINGS" in line:
+      for word in line.split():
+        if "NREPLICAS=" in word:
+          nreplicas = word.replace("NREPLICAS=", "")
+        elif "NATOMS=" in word:
+          natoms = word.replace("NATOMS=", "")
+  ifile.close()
+  cmd = [
+    executible,
+    "driver",
+    "--plumed",
+    plumed_file,
+    "--natoms",
+    str(natoms),
+    "--parse-only",
+    "--kt",
+    "2.49",
+  ]
+  # Add everything to ensure we can run with replicas if needs be
+  if int(nreplicas) > 1:
+    cmd = (
+      ["mpirun", "--oversubscribe", "-np", str(nreplicas)]
+      + cmd
+      + ["--multi", str(nreplicas)]
+    )
+  if printjson:
     plumed_file = os.path.basename(filename)
-    # Read in the plumed inpt
-    nreplicas, natoms, ifile = 1, 100000, open( filename ) 
-    for line in ifile.readlines() :
-        if "#SETTINGS" in line :
-            for word in line.split() :
-                if "NREPLICAS=" in word : nreplicas = word.replace("NREPLICAS=","")
-                elif "NATOMS=" in word : natoms = word.replace("NATOMS=","")
-    ifile.close()
-    cmd = [executible, 'driver', '--plumed', plumed_file, '--natoms', str(natoms), '--parse-only', '--kt', '2.49']
-    # Add everything to ensure we can run with replicas if needs be
-    if int(nreplicas)>1 : cmd = ['mpirun', '--oversubscribe', '-np', str(nreplicas)] + cmd + ['--multi', str(nreplicas)]
-    if printjson :
-       plumed_file = os.path.basename(filename)
-       # Add the shortcutfile output if the user has asked for it 
-       cmd = cmd + ['--shortcut-ofile', jsondir + plumed_file + ".json"]
-       # Add the value dictionary if the user has asked for it
-       cmd = cmd + ['--valuedict-ofile', jsondir + plumed_file + "_values.json"] 
-    # raw std output - to be zipped
-    outfile=filename + "." + executible + ".stdout.txt"
-    # raw std error - to be zipped
-    errtxtfile=filename + "." + executible + ".stderr.txt"
-    # std error markdown page (with only the first 1000 lines of stderr.txt)
-    errfile=filename + "." + executible + ".stderr.md"
-    with open(outfile,"w") as stdout:
-        with open(errtxtfile,"w") as stderr:
-             with cd(run_folder):
-                 for bkpf in glob.glob("bck.*") : 
-                     if os.path.isfile(bkpf) : os.remove(bkpf)
-                 try:
-                     plumed_out = subprocess.run(cmd, text=True, stdout=stdout, stderr=stderr, timeout=cmdTimeout )
-                     returnCode = plumed_out.returncode
-                 except subprocess.TimeoutExpired:
-                     returnCode=-1
-                    
-    # write header and preamble to errfile
-    with open(errfile,"w") as stderr:
-        if len(header)>0 : 
-            print(header,file=stderr)
-        print("Stderr for source: ",re.sub("^data/","",filename),"  ",file=stderr)
-        print("Download: [zipped raw stdout](" + plumed_file + "." + executible + ".stdout.txt.zip) - [zipped raw stderr](" + plumed_file + "." + executible + ".stderr.txt.zip) ",file=stderr)
-        if ghmarkdown : print("{% raw %}\n<pre style=\"overflow:scroll;\">",file=stderr)
-        else : print("<pre style=\"overflow:scroll;\">",file=stderr)
-        # now we print the first 1000 lines of errtxtfile to errfile
-        with open(errtxtfile, "r") as stdtxterr:
-          # line counter
-          lc = 0
-          # print comment
-          print("#! Only the first 1000 rows of the error file are shown below", file=stderr)
-          print("#! To inspect the full error file, please download the zipped raw stderr file above", file=stderr)
-          while True:
-            lc += 1
-            # read line by line
-            line = stdtxterr.readline()
-            # if end of file or max number of lines reached, break
-            if(not line or lc>1000): break
-            # print line to stderr
-            print(line.strip(), file=stderr)
-          # close stderr
-          if ghmarkdown : print("</pre>\n{% endraw %}",file=stderr)
-          else : print("</pre>\n",file=stderr)
-    # compress both outfile and errtxtfile
-    zip(outfile)
-    zip(errtxtfile)
-    return returnCode
+    # Add the shortcutfile output if the user has asked for it
+    cmd = cmd + ["--shortcut-ofile", jsondir + plumed_file + ".json"]
+    # Add the value dictionary if the user has asked for it
+    cmd = cmd + ["--valuedict-ofile", jsondir + plumed_file + "_values.json"]
+  # raw std output - to be zipped
+  outfile = filename + "." + executible + ".stdout.txt"
+  # raw std error - to be zipped
+  errtxtfile = filename + "." + executible + ".stderr.txt"
+  # std error markdown page (with only the first 1000 lines of stderr.txt)
+  errfile = filename + "." + executible + ".stderr.md"
+  with open(outfile, "w") as stdout:
+    with open(errtxtfile, "w") as stderr:
+      with cd(run_folder):
+        for bkpf in glob.glob("bck.*"):
+          if os.path.isfile(bkpf):
+            os.remove(bkpf)
+        try:
+          plumed_out = subprocess.run(
+            cmd, text=True, stdout=stdout, stderr=stderr, timeout=cmdTimeout
+          )
+          returnCode = plumed_out.returncode
+        except subprocess.TimeoutExpired:
+          returnCode = -1
 
-def manage_incomplete_inputs( inpt ) :
-   """
-      Managet the PLUMED input files for tutorials that should contain solution
-
-      In a tutorial you can create PLUMED input files with the instruction __FILL__
-      This tells the tutees they need to add something to that input in order to make the 
-      calculation work.  When you add these you should add a corrected input after the version
-      with __FILL__ and after the instruction #SOLUTION.  It is this completed input that will be 
-      tested
-
-      Keyword arguments:
-      inpt -- A string containing the incomplete and complete PLUMED inputs
-   """
-   if "__FILL__" in inpt :
-       insolution, complete, incomplete = False, "", ""
-       for line in inpt.splitlines() :
-           if "#SOLUTION" in line : insolution=True
-           elif insolution : complete += line + "\n"
-           elif not insolution : incomplete += line + "\n"
-       return complete, incomplete
-   return inpt, ""
-
-def get_cltoolfile_html( inpt, name, plumedexe ) :
-    """
-       Generate an html representation of the input file for a PLUMED command line tool
-    
-       The html representation of the input to a command line tool has toopltips that tell you what the keywords do.
-
-       Keyword arguments:
-       inpt -- A string containing the input you want to get the html for
-       name -- The name to use for this input in the html
-       plumedexe -- The plumed executibles that were used.  The last one is the one that is used to create the input file annotations
-    """ 
-    # need to get the name of the command 
-    if inpt.splitlines()[0].split("=")[0]!="#TOOL" : raise Exception("could not find tool that this input file is for")
-    tool = inpt.splitlines()[0].split("=")[1]
-    # Create the lexer that will generate the pretty plumed input
-    lexerfile = os.path.join(os.path.dirname(__file__),"PlumedCLFileLexer.py")
-    plumed_lexer = load_lexer_from_file(lexerfile, "PlumedCLFileLexer" )
-     # Get the plumed syntax file
-    defstr, keyword_dict = inpt, getPlumedSyntax( plumedexe )
-    # Find the default values in the dictionary
-    for key, dicti in keyword_dict["cltools"][tool]["syntax"].items() :
-        if "default" not in dicti.keys() or dicti["default"]=="off" or key in inpt : continue
-        defstr += "\n" + key + " " + dicti["default"]
-    if defstr!=inpt :
-        inpt = "#NODEFAULT plumed\n" + inpt + " \n#DEFAULT plumed\n" + defstr + " \n#ENDDEFAULT plumed\n"
-    # Setup the formatter 
-    formatfile = os.path.join(os.path.dirname(__file__),"PlumedFormatter.py")
-    valuedict, actions = {}, set()
-    plumed_formatter = load_formatter_from_file(formatfile, "PlumedFormatter", keyword_dict=keyword_dict["cltools"], input_name=name, hasload=False, broken=False, auxinputs=[], auxinputlines=[], valuedict=valuedict, actions=actions, checkaction="" )  
-    return highlight( inpt, plumed_lexer, plumed_formatter )
-
-def get_cltoolarg_html( inpt, name, plumedexe ) :
-    """
-       Generate an html representation of the input to PLUMED command line tool
-
-       The html representation of the input to a command line tool has toopltips that tell you what the keywords do.
-
-       Keyword arguments:
-       inpt -- A string containing the input you want to get the html for
-       name -- The name to use for this input in the html
-       plumedexe -- The plumed executibles that were used.  The last one is the one that is used to create the input file annotations
-    """
-    # Get the cltool that we are using
-    pl, tool = inpt.split()[0], inpt.split()[1]
-    if re.search(r"^mpirun\s+-np\s+[0-9]+\s+plumed",inpt) : 
-       tool = inpt.split()[4]
-       pl = inpt.split()[3]
-    if re.search(r"^plumed\s+\--no-mpi\s+", inpt) :
-       tool = inpt.split()[2]  
-    if pl!="plumed" and pl!="plumed-runtime" :
-       raise Exception("first word in the command should be plumed or plumed-runtime")
-    # Create the lexer that will generate the pretty plumed input
-    lexerfile = os.path.join(os.path.dirname(__file__),"PlumedCLtoolLexer.py")
-    plumed_lexer = load_lexer_from_file(lexerfile, "PlumedCLtoolLexer" )
-    # Get the plumed syntax file
-    fileoutstr, defstr, keyword_dict = "", inpt, getPlumedSyntax( plumedexe )
-    if ">" in inpt :
-       fileoutstr = ">" + inpt.split(">")[1]
-       defstr = inpt.split(">")[0]
-    # Find the default values in the dictionary
-    ishelp = False
-    if len(inpt.split())>2 and (inpt.split()[2]=="-h" or inpt.split()[2]=="--help") :
-       ishelp = True 
-    if not ishelp and keyword_dict["cltools"][tool]["inputtype"]!="file" : 
-       for key, dicti in keyword_dict["cltools"][tool]["syntax"].items() :
-           if "default" not in dicti.keys() or dicti["default"]=="off" or key in inpt : continue
-           defstr += " " + key + " " + dicti["default"]
-       if (defstr+fileoutstr)!=inpt :
-           inpt = "#NODEFAULT plumed\n" + inpt + " \n#DEFAULT plumed\n" + defstr + fileoutstr + " \n#ENDDEFAULT plumed\n"
-    # Setup the formatter
-    formatfile = os.path.join(os.path.dirname(__file__),"PlumedFormatter.py")
-    valuedict, actions = {}, set()
-    plumed_formatter = load_formatter_from_file(formatfile, "PlumedFormatter", keyword_dict=keyword_dict["cltools"], input_name=name, hasload=False, broken=False, auxinputs=[], auxinputlines=[], valuedict=valuedict, actions=actions, checkaction="" )  
-    return highlight( inpt, plumed_lexer, plumed_formatter )
-
-def get_html( inpt, name, outloc, tested, broken, plumedexe, usejson=None, maxchecks=None, actions=set({}), ghmarkdown=True, checkaction="", checkactionkeywords=set({}) ) :
-    """
-       Generate the html representation of a PLUMED input file
-
-       The html representation of a PLUMED input file has tooltips that 
-       tell you what the keywords represent, a badge that shows whether the input
-       works and clickable labels that provide information about the quantities that 
-       are calculated.  This function uses test_plumed to check if the plumed inpt can be parsed.
-
-       Keyword arguments:
-       inpt -- A string containing the PLUMED input
-       name -- The name to use for this input in the html
-       outloc -- The location of the output files that were generated by test_plumed relative to the file that contains the input
-       tested -- The versions of plumed that were testd
-       broken -- The outcome of running test plumed on the input
-       plumedexe -- The plumed executibles that were used.  The first one is the one that should be used to create the input file annotations
-       usejson -- Bool that tells you whether or not to look for json files that are generated by plumed driver
-       maxchecks -- Maximum number of checks to perform on plumed input.  Set this to reduce computational expense
-       actions -- Set to store all the actions that have been used in the input
-    """
-    
-    # Check if we are looking for json files
-    if usejson is None :
-       searchjson = False
-       if not any(broken) : searchjson = True
-    else : searchjson = usejson
-
-    # If we find the fill command then split up the input file to find the solution
-    inpt, incomplete = manage_incomplete_inputs( inpt )
-
-    # Create a list of all the auxiliary input files that are needed by the plumed input 
-    inputfiles, inputfilelines, nreplicas = [], [], 1
-    for line in inpt.splitlines() :
-        if "#SETTINGS" in line :
-           for word in line.split() :
-               if "NREPLICAS=" in word : 
-                   nreplicas = int(word.replace("NREPLICAS=",""))
-               elif "MOLFILE=" in word : 
-                   molfile = word.replace("MOLFILE=","")
-                   if os.path.isfile(molfile) : 
-                      iff = open( molfile, 'r' )
-                      content = iff.read()
-                      iff.close()
-                      inputfiles.append(molfile)
-                      inputfilelines.append("1-5")
-                      inputfilelines.append( str(len(content.splitlines())-4) + "-" + str(len(content.splitlines())) ) 
-                   else :
-                      warnings.warn("file " + molfile + " found in MOLFILE setting but file is not present")
-               elif "INPUTFILES=" in word : 
-                   for n in word.replace("INPUTFILES=","").split(",") : 
-                      if os.path.isfile(n) : inputfiles.append( n )
-                      else : raise Exception("file " + n + " found in list of INPUTFILES but file is not present")
-               elif "INPUTFILELINES=" in word : 
-                   inputfilelines = word.replace("INPUTFILELINES=","").split(",")
-
-    # Check for include files
-    foundincludedfiles, srcdir = True, str(pathlib.PurePosixPath(name).parent)
-    if not any(broken) and "INCLUDE" in inpt : foundincludedfiles, inpt = resolve_includes( srcdir, inpt, nreplicas, foundincludedfiles )
-
-    # Check if there is a LOAD command in the input
-    found_load = "LOAD " in inpt
-
-    # Check for shortcut file and build the modified input to read the shortcuts
-    if os.path.exists( name + '.json' ) and searchjson :
-       # Read json file containing shortcuts
-       with open(name + '.json') as f :
-           try:
-              shortcutdata = json.load(f)
-           except json.JSONDecodeError as ve:
-              raise Exception("invalid json for shortcut dictionary", ve)
-       # Put everything in to resolve the expansions.  We call this function recursively just in case there are shortcuts in shortcuts
-       final_inpt = resolve_expansions( inpt, shortcutdata )
-    else : final_inpt = inpt  
-    # Remove the tempory files that we created
-    if os.path.exists( name + '.json' ) : os.remove( name + ".json")  
-
-    # Check for value dictionary to use to create labels
-    if os.path.exists( name + '_values.json') and searchjson :
-       with open( name + '_values.json') as f :
-           try:
-              valuedict = json.load(f)
-           except json.JSONDecodeError as ve:
-              raise Exception("invalid json for value dictionary", ve)
-    else : valuedict = {}
-    # Remove the tempory files that we created
-    if os.path.exists( name + '_values.json') : os.remove( name + "_values.json")
-
-    # Create the lexer that will generate the pretty plumed input
-    lexerfile = os.path.join(os.path.dirname(__file__),"PlumedLexer.py")
-    plumed_lexer = load_lexer_from_file(lexerfile, "PlumedLexer" )
-    # Get the plumed syntax file
-    keyword_dict = getPlumedSyntax( plumedexe )
-    # Setup the formatter
-    formatfile = os.path.join(os.path.dirname(__file__),"PlumedFormatter.py")
-    plumed_formatter = load_formatter_from_file(formatfile, "PlumedFormatter", keyword_dict=keyword_dict, input_name=name, hasload=found_load, broken=any(broken), auxinputs=inputfiles, auxinputlines=inputfilelines, valuedict=valuedict, actions=actions, checkaction=checkaction )
-
-    # Now generate html of input
-    html = '<div class="plumedInputContainer">\n'
-    html += '<div class="plumedpreheader">\n'
-    html += f'<div class="headerInfo" id="value_details_{name}"> Click on the labels of the actions for more information on what each action computes </div>\n'
-    html += '<div class="containerBadge">\n'
-    for i in range(len(tested)) :
-        html +='<div class="headerBadge">'
-        btype = 'passing-green.svg'
-        if broken[i] :
-           btype = 'failed-red.svg'
-        #this if can be collapsed in a f'<a href="{"" if ghmarkdown else "../"}{outloc}.{plumedexe[i]}.stderr">'
-        #but like this it might be clearer, what do you think?
-        if ghmarkdown :
-           html += f'<a href="{outloc}.{plumedexe[i]}.stderr">'
-        else :
-           html += f'<a href="../{outloc}.{plumedexe[i]}.stderr">'
-        html += f'<img src="https://img.shields.io/badge/{tested[i]}-{btype}" alt="tested on{tested[i]}" />'
-        html += '</a>'
-        html += '</div>\n'
-
-    if found_load :
-       html += '<div class="headerBadge">'
-       html += '<img src="https://img.shields.io/badge/with-LOAD-yellow.svg" alt="tested on master" />'
-       html += '</div>\n'
-
-    if len(incomplete)>0 : 
-       html += '<div class="headerBadge">'
-       html += f'<img class="toggler" src="https://img.shields.io/badge/{tested[-1]}-incomplete-yellow.svg" alt="tested on {tested[-1]}"'
-       html += f" onmouseup='toggleDisplay(\"{name}\")' onmousedown='toggleDisplay(\"{name}\")'/>"
-       html += "</div>\n"
-
-    html += '</div>\n</div>\n' 
-
-    if len(incomplete)>0 : 
-       # This creates the input with the __FILL__ 
-       html += "<div id=\"" + name + "_short\">\n"
-       # html += highlight( final_inpt, plumed_lexer, HtmlFormatter() )
-       html += highlight( incomplete, plumed_lexer, plumed_formatter )
-       html += "</div>\n"
-       # This is the solution with the commplete input
-       html += "<div style=\"display:none;\" id=\"" + name + "_long\">"
-       plumed_formatter.egname = plumed_formatter.egname + "_sol"
-       # html += highlight( final_inpt, plumed_lexer, HtmlFormatter() )
-       html += highlight( final_inpt, plumed_lexer, plumed_formatter )
-       html += '</div>\n'
-    else : 
-       # html += highlight( final_inpt, plumed_lexer, HtmlFormatter() )
-       html += highlight( final_inpt, plumed_lexer, plumed_formatter )
-    #close the html = '<div class="plumedInputContainer">\n'
-    html += '</div>\n'
-    # Now remove keywords that appear in examples
-    mykeywords = plumed_formatter.getCheckActionKeywords()
-    for key in mykeywords : 
-        if key in checkactionkeywords :
-           checkactionkeywords.remove(key)
-
-    # Test output is valid parsable html
-    try :
-       etree.parse(StringIO(html), etree.HTMLParser(recover=False))
-    except etree.XMLSyntaxError as e:
-       raise Exception("Generated html is invalid as " + str(e.error_log) + " plumed input is \n\n" + final_inpt ) from e
-
-    # Check everything that is marked as a clickable value has something that will appear
-    # when you click it
-    nchecks, soup = 0, BeautifulSoup( html, "html.parser" )
-    for val in soup.find_all("b") :
-        if "onclick" in val.attrs.keys() :
-           nchecks, vallabels = nchecks + 1, val.attrs["onclick"].split("\"")
-           if maxchecks is not None and nchecks>maxchecks : 
-              warnings.warn("Only checked the html for the first " + str(maxchecks) + " of the " + str(len(soup.find_all("b"))) + " labels in input file to reduce computational expense. The output is most likely fine but has not been checked as carefully as inputs with fewer values")
-              break
-           if not soup.find("span", {"id": vallabels[3]}) : warnings.warn("Problems with generated as label hidden box for label " + vallabels[3] + " is missing")
-           if not soup.find("div", {"id": "value_details_" + vallabels[1]}) : raise Exception("Generated html is invalid as there is no place to show data for " + vallabell[1])
-
-    # Now check the togglers
-    nchecks = 0 
-    for val in soup.find_all(attrs={'class': 'toggler'}) :
-        nchecks = nchecks + 1 
-        if maxchecks is not None and nchecks>maxchecks : 
-           warnings.warn("Only checked the html for the first " + str(maxchecks) + " of the " + str(len(soup.find_all(attrs={'class': 'toggler'}))) + " shortcuts in the input file to reduce computational expense. The output is most likely fine but has not been checked as carefully as inputs with fewer shortcuts")
-           break
-        if "onclick" in val.attrs.keys() :
-           switchval = val.attrs["onclick"].split("\"")[1]
-           if not soup.find("span",{"id": switchval + "_long"} ) : raise Exception("Generated html is invalid as could not find " + switchval + "_long") 
-           if not soup.find("span",{"id": switchval + "_short"} ) : raise Exception("Generated html is invalid as could not find " + switchval + "_short")
-        elif "onmousedown" in val.attrs.keys() :
-           switchval = val.attrs["onmousedown"].split("\"")[1]
-           if not soup.find("div",{"id": switchval + "_long"} ) : raise Exception("Generated html is invalid as could not find " + switchval + "_long")
-           if not soup.find("div",{"id": switchval + "_short"} ) : raise Exception("Generated html is invalid as could not find " + switchval + "_short")
-        else : raise Exception("Could not find toggler command for " + val)
-    return html
-
-def get_mermaid( executible, inpt, force,*, test_plumed_kwargs={} ) :
-    """
-     Generate the mermaid graph showing how data passes through PLUMED input file
-
-     Keyword arguments:
-     inpt -- A string containing the PLUMED input
-     force -- Bool that if true ensures we show the graph for the backwards pass through the action list
-     test_plumed_kwargs -- a dictionary of extra keywords to pass to the test_plumed utility, useful for passing an"header"
-    """
-    # Write the plumed input to a file
-    iff = open( "mermaid_plumed.dat", "w+")
-    iff.write(inpt+ "\n")
-    iff.close()
-    # Now check the input is OK
-    broken = test_plumed( executible, "mermaid_plumed.dat",**test_plumed_kwargs)
-    if broken!=0 : raise Exception("invalid plumed input file -- cannot create mermaid graph")
-    # Run mermaid
-    cmd = [executible, 'show_graph', '--plumed', 'mermaid_plumed.dat', '--out', 'mermaid.md']
-    if force : cmd.append("--force")
-    plumed_out = subprocess.run(cmd, text=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT )
-    if plumed_out.returncode!=0 : raise Exception("error running plumed show_graph")
-    mf = open("mermaid.md")
-    mermaid = mf.read()
-    mf.close()
-    # Remove stuff that was created
-    os.remove("mermaid_plumed.dat")
-    os.remove("mermaid.md")
-    return mermaid 
-
-def resolve_includes( srcdir, inpt, nreplicas, foundfiles ) :
-    if not foundfiles or "INCLUDE" not in inpt : return foundfiles, inpt
-
-    incontinuation, final_inpt, clines = False, "", "" 
-    for line in inpt.splitlines() :
-        # Empty the buffer that holds the input for this line if we are not in a continuation
-        if not incontinuation : clines = ""
-        # Check for start and end of continuation
-        if "..." in line and incontinuation : incontinuation=False
-        elif "..." in line and not incontinuation : incontinuation=True
-        # Build up everythign that forms part of input for one action
-        clines += line + "\n"
-        # Just continue if we don't have the full line
-        if incontinuation : continue
-
-        # Now check if there is an include
-        if "INCLUDE" in clines :
-           # Split up the line 
-           iscomment, filename = False, ""
-           for w in clines.split():
-               if "#" in w and filename=="" : iscomment=True
-               elif "FILE=" in w : filename = w.replace("FILE=","") 
-           if iscomment : 
-              final_inpt += clines 
-              continue
-           if filename=="" : raise Exception("could not find name of file to include")
-           if not os.path.exists(filename) : foundfiles = False 
-           splitname = filename.rsplit(".",1)
-           if len(splitname)>2 : raise Exception("cannot deal with included file named " + filename )
-
-           final_inpt += "#SHORTCUT " + filename + "\n" + clines + "#EXPANSION " + filename + "\n# The command:\n"
-           final_inpt += "# " + clines+ "# ensures PLUMED loads the contents of the file called " + filename + "\n" 
-           if nreplicas>1 and os.path.exists( srcdir + "/" + splitname[0] + ".0." + splitname[1] ) :
-              final_inpt += "# There are different versions of this file on each replica\n"
-              for i in range(nreplicas) : 
-                  f = open( srcdir + "/" + splitname[0] + "." + str(i) + "." + splitname[1], "r" )
-                  include_contents = f.read()
-                  f.close() 
-                  final_inpt += "# The contents of the version of this file (" + splitname[0] + "." + str(i) + "." + splitname[1] + ") on replica " + str(i) + " is shown below.\n"
-                  foundfiles, parsed_inpt = resolve_includes( srcdir, include_contents, nreplicas, foundfiles )
-                  final_inpt += parsed_inpt
-              final_inpt += "#(click the red comment to hide this expanded text).\n"
-              if final_inpt.endswith("\n") : final_inpt += "#ENDEXPANSION " + filename + "\n"
-              else : final_inpt += "\n#ENDEXPANSION " + filename + "\n"
-           else : 
-              f = open( srcdir + "/" + filename, "r" )
-              include_contents = f.read()
-              f.close()
-              final_inpt += "# The contents of this file are shown below (click the red comment to hide them).\n" 
-              foundfiles, parsed_inpt = resolve_includes( srcdir, include_contents, nreplicas, foundfiles )
-              if parsed_inpt.endswith("\n") : final_inpt += parsed_inpt + "#ENDEXPANSION " + filename + "\n"
-              else : final_inpt += parsed_inpt + "\n#ENDEXPANSION " + filename + "\n"
-        else : final_inpt += clines         
-    return foundfiles, final_inpt
+  # write header and preamble to errfile
+  with open(errfile, "w") as stderr:
+    if len(header) > 0:
+      print(header, file=stderr)
+    print("Stderr for source: ", re.sub("^data/", "", filename), "  ", file=stderr)
+    print(
+      "Download: [zipped raw stdout]("
+      + plumed_file
+      + "."
+      + executible
+      + ".stdout.txt.zip) - [zipped raw stderr]("
+      + plumed_file
+      + "."
+      + executible
+      + ".stderr.txt.zip) ",
+      file=stderr,
+    )
+    if ghmarkdown:
+      print('{% raw %}\n<pre style="overflow:scroll;">', file=stderr)
+    else:
+      print('<pre style="overflow:scroll;">', file=stderr)
+    # now we print the first 1000 lines of errtxtfile to errfile
+    with open(errtxtfile, "r") as stdtxterr:
+      # line counter
+      lc = 0
+      # print comment
+      print(
+        "#! Only the first 1000 rows of the error file are shown below",
+        file=stderr,
+      )
+      print(
+        "#! To inspect the full error file, please download the zipped raw stderr file above",
+        file=stderr,
+      )
+      while True:
+        lc += 1
+        # read line by line
+        line = stdtxterr.readline()
+        # if end of file or max number of lines reached, break
+        if not line or lc > 1000:
+          break
+        # print line to stderr
+        print(line.strip(), file=stderr)
+      # close stderr
+      if ghmarkdown:
+        print("</pre>\n{% endraw %}", file=stderr)
+      else:
+        print("</pre>\n", file=stderr)
+  # compress both outfile and errtxtfile
+  zip(outfile)
+  zip(errtxtfile)
+  return returnCode
 
 
-def resolve_expansions( inpt, jsondata ) :
-    # Stop expanding if we have reached the bottom 
-    if len(jsondata.keys())==0 : return inpt + "\n"
+def manage_incomplete_inputs(inpt):
+  """
+  Managet the PLUMED input files for tutorials that should contain solution
 
-    incontinuation, final_inpt, clines = False, "", ""
-    for line in inpt.splitlines() :        
-        # Empty the buffer that holds the input for this line if we are not in a continuation
-        if not incontinuation : clines = ""
-        # Check for start and end of continuation
-        if "..." in line and incontinuation : incontinuation=False
-        elif "..." in line and not incontinuation : incontinuation=True
-        # Build up everythign that forms part of input for one action
-        clines += line + "\n"
-        # Just continue if we don't have the full line
-        if incontinuation : continue
-        # Find the label of this line if it has one
-        label = ""
-        if "LABEL=" in clines :
-           afterlab = clines[clines.index("LABEL=") + len("LABEL="):]
-           label = afterlab.split()[0]
-        elif clines.find(":") : label = clines.split(":")[0].strip()
-        if len(label)>0 and label in jsondata :
-           if "expansion" in jsondata[label] :
-              final_inpt += "#SHORTCUT " + label + "\n"
-              if "defaults" in jsondata[label] : final_inpt += "#NODEFAULT " + label + "\n" + clines
-              else : final_inpt += clines
-              # Add long version with defaults to input 
-              if "defaults" in jsondata[label] and "..." in clines :
-                 alldat, bef = clines.split("\n"), ""
-                 for i in range(len(alldat)-2) : bef += alldat[i] + "\n"
-                 final_inpt += "#DEFAULT " + label + "\n" + bef + jsondata[label]["defaults"] + "\n" + alldat[-2] + "\n#ENDDEFAULT " + label + "\n"
-              elif "defaults" in jsondata[label]  : final_inpt += "#DEFAULT " + label + "\n" + clines.strip() + " " + jsondata[label]["defaults"] + "\n#ENDDEFAULT " + label + "\n"
-              # Add stuff for long version of input in collapsible
-              final_inpt += "#EXPANSION " + label + "\n# PLUMED interprets the command:\n"
-              for gline in clines.splitlines() : final_inpt += "# " + gline + "\n"
-              local_json = dict(jsondata[label]) 
-              local_json.pop("expansion", "defaults" )
-              final_inpt += "# as follows (Click the red comment above to revert to the short version of the input):\n" + resolve_expansions( jsondata[label]["expansion"], local_json )
-              final_inpt += "#ENDEXPANSION " + label + "\n"
-           elif "defaults" in jsondata[label] :
-              final_inpt += "#NODEFAULT " + label + "\n" + clines
-              if "..." in clines :
-                 alldat, bef = clines.split("\n"), ""
-                 for i in range(len(alldat)-2) : bef += alldat[i] + "\n"
-                 final_inpt += "#DEFAULT " + label + "\n" + bef + jsondata[label]["defaults"] + "\n" + alldat[-2] + "\n#ENDDEFAULT " + label + "\n"
-              else : final_inpt += "#DEFAULT " + label + "\n" + clines.strip() + " " + jsondata[label]["defaults"] + "\n#ENDDEFAULT " + label + "\n"
-        else : final_inpt += clines
-    return final_inpt
+  In a tutorial you can create PLUMED input files with the instruction __FILL__
+  This tells the tutees they need to add something to that input in order to make the
+  calculation work.  When you add these you should add a corrected input after the version
+  with __FILL__ and after the instruction #SOLUTION.  It is this completed input that will be
+  tested
 
-def get_html_header() :
-    """
-       Get the information that needs to go in the header of the html file to make the interactive PLUMED
-       inputs work
-    """
-    headerfilename = os.path.join(os.path.dirname(__file__),"assets/header.html")
-    hfile = open( headerfilename )
-    codes = hfile.read()
-    hfile.close()
-    return codes
+  Keyword arguments:
+  inpt -- A string containing the incomplete and complete PLUMED inputs
+  """
+  if "__FILL__" in inpt:
+    insolution, complete, incomplete = False, "", ""
+    for line in inpt.splitlines():
+      if "#SOLUTION" in line:
+        insolution = True
+      elif insolution:
+        complete += line + "\n"
+      elif not insolution:
+        incomplete += line + "\n"
+    return complete, incomplete
+  return inpt, ""
 
-def get_javascript() :
-    """
-       Get the javascript from the header of the html file to make the interactive PLUMED inputs work
-    """
-    inscript, fullheader, jscode = False, get_html_header().splitlines(), ""
-    for line in fullheader :
-        if "</script>" in line and inscript :
-            inscript = False
-            break
-        elif "<script>" in line :
-            inscript = True
-        elif inscript :
-            if ("<style>" in line) or ("</style>" in line) or ("<script>" in line) or ("</script>" in line) : 
-               raise Exception('found invalid html tag in javascript line ' + line)
-            jscode += line + "\n"
-    return jscode
 
-def get_css() :
-    """
-       Get the css from the header of the html file to make the interactive PLUMED inputs work
-    """
-    inscript, fullheader, css = False, get_html_header().splitlines(), ""
-    for line in fullheader :
-        if "</style>" in line and inscript :
-            inscript = False
-            break
-        elif "<style>" in line :
-            inscript = True
-        elif inscript :
-            if ("<style>" in line) or ("</style>" in line) or ("<script>" in line) or ("</script>" in line) : 
-               raise Exception('found invalid html tag in css line ' + line)
-            css += line + "\n"               
-    return css 
+def get_cltoolfile_html(inpt, name, plumedexe):
+  """
+  Generate an html representation of the input file for a PLUMED command line tool
 
-def compare_to_reference( output, reference ) :
-    """
-      Compare the html that is output by PlumedFormatter with the reference data.  This function is used for 
-      testing PlumedToHMTL
-    """
-    soup = BeautifulSoup( output, "html.parser" ) 
-    # Check that comments in PLUMED input have been detected correctly
-    if "comment" in reference.keys() :
-       soup_comments = soup.find_all(attrs={'class': 'comment'})
-       if len(soup_comments)!=len(reference["comments"]) : return False
-       for i in range(len(soup_comments)) :
-           if soup_comments[i].get_text()!=reference["comments"][i] : return False
+  The html representation of the input to a command line tool has toopltips that tell you what the keywords do.
 
-    print("Comments fine")
-    # Check that everything that should be rendered as a tooltip has been rendered as a tooltip
-    # This is action names and keywords
-    if "tooltips" in reference.keys() :
-       soup_tooltips = soup.find_all(attrs={'class': 'plumedtooltip'})
-       print("CHECK TOOLTIP",  soup_tooltips )
-       print("TOOLTIP NUMBER CORRECT", len(soup_tooltips), len(reference["tooltips"]))
-       if len(soup_tooltips)!=len(reference["tooltips"]) :
-         print ("REFERENCE tooltips: ",reference["tooltips"])
-         print ("FOUND tooltips:     ",[x.contents[0] for x in soup_tooltips])
-         return False
-       for i in range(len(soup_tooltips)) :
-           print("COMPARISON", soup_tooltips[i].contents[0], reference["tooltips"][i] )
-           if soup_tooltips[i].contents[0]!=reference["tooltips"][i] : return False
+  Keyword arguments:
+  inpt -- A string containing the input you want to get the html for
+  name -- The name to use for this input in the html
+  plumedexe -- The plumed executibles that were used.  The last one is the one that is used to create the input file annotations
+  """
+  # need to get the name of the command
+  if inpt.splitlines()[0].split("=")[0] != "#TOOL":
+    raise Exception("could not find tool that this input file is for")
+  tool = inpt.splitlines()[0].split("=")[1]
+  # Create the lexer that will generate the pretty plumed input
+  lexerfile = os.path.join(os.path.dirname(__file__), "PlumedCLFileLexer.py")
+  plumed_lexer = load_lexer_from_file(lexerfile, "PlumedCLFileLexer")
+  # Get the plumed syntax file
+  defstr, keyword_dict = inpt, getPlumedSyntax(plumedexe)
+  # Find the default values in the dictionary
+  for key, dicti in keyword_dict["cltools"][tool]["syntax"].items():
+    if "default" not in dicti.keys() or dicti["default"] == "off" or key in inpt:
+      continue
+    defstr += "\n" + key + " " + dicti["default"]
+  if defstr != inpt:
+    inpt = (
+      "#NODEFAULT plumed\n"
+      + inpt
+      + " \n#DEFAULT plumed\n"
+      + defstr
+      + " \n#ENDDEFAULT plumed\n"
+    )
+  # Setup the formatter
+  formatfile = os.path.join(os.path.dirname(__file__), "PlumedFormatter.py")
+  valuedict, actions = {}, set()
+  plumed_formatter = load_formatter_from_file(
+    formatfile,
+    "PlumedFormatter",
+    keyword_dict=keyword_dict["cltools"],
+    input_name=name,
+    hasload=False,
+    broken=False,
+    auxinputs=[],
+    auxinputlines=[],
+    valuedict=valuedict,
+    actions=actions,
+    checkaction="",
+  )
+  return highlight(inpt, plumed_lexer, plumed_formatter)
 
-    return True
 
-def processMarkdown( filename, plumedexe, plumed_names, actions, jsondir="./", ghmarkdown=True,
-        *,test_plumed_kwargs={} ) :
-    """
-        Process a markdown file that contains PLUMED input files using PlumedtoHTML
+def get_cltoolarg_html(inpt, name, plumedexe):
+  """
+  Generate an html representation of the input to PLUMED command line tool
 
-        Keyword arguments:
-        filename -- the name of the markdown file
-        plumedexe -- a tuple of plumed executible names for testing plumed.
-        plumed_names -- the names of the plumed executibles to use in the badges
-        actions -- names of actions used in the plumed inputs in this markdown file
-        jsondir -- The directory in which to output the files containing the expansions of the shortcuts and the value dictionaries 
-        test_plumed_kwargs -- a dictionary of extra keywords to pass to the test_plumed utility, only "header" and "cmdTimeout" works
-    """
-    if not os.path.exists(filename) :
-       raise RuntimeError("Found no file called " + filename + " in lesson")
+  The html representation of the input to a command line tool has toopltips that tell you what the keywords do.
 
-    with open( filename, "r" ) as f:
-       inp = f.read()
+  Keyword arguments:
+  inpt -- A string containing the input you want to get the html for
+  name -- The name to use for this input in the html
+  plumedexe -- The plumed executibles that were used.  The last one is the one that is used to create the input file annotations
+  """
+  # Get the cltool that we are using
+  pl, tool = inpt.split()[0], inpt.split()[1]
+  if re.search(r"^mpirun\s+-np\s+[0-9]+\s+plumed", inpt):
+    tool = inpt.split()[4]
+    pl = inpt.split()[3]
+  if re.search(r"^plumed\s+\--no-mpi\s+", inpt):
+    tool = inpt.split()[2]
+  if pl != "plumed" and pl != "plumed-runtime":
+    raise Exception("first word in the command should be plumed or plumed-runtime")
+  # Create the lexer that will generate the pretty plumed input
+  lexerfile = os.path.join(os.path.dirname(__file__), "PlumedCLtoolLexer.py")
+  plumed_lexer = load_lexer_from_file(lexerfile, "PlumedCLtoolLexer")
+  # Get the plumed syntax file
+  fileoutstr, defstr, keyword_dict = "", inpt, getPlumedSyntax(plumedexe)
+  if ">" in inpt:
+    fileoutstr = ">" + inpt.split(">")[1]
+    defstr = inpt.split(">")[0]
+  # Find the default values in the dictionary
+  ishelp = False
+  if len(inpt.split()) > 2 and (inpt.split()[2] == "-h" or inpt.split()[2] == "--help"):
+    ishelp = True
+  if not ishelp and keyword_dict["cltools"][tool]["inputtype"] != "file":
+    for key, dicti in keyword_dict["cltools"][tool]["syntax"].items():
+      if "default" not in dicti.keys() or dicti["default"] == "off" or key in inpt:
+        continue
+      defstr += " " + key + " " + dicti["default"]
+    if (defstr + fileoutstr) != inpt:
+      inpt = (
+        "#NODEFAULT plumed\n"
+        + inpt
+        + " \n#DEFAULT plumed\n"
+        + defstr
+        + fileoutstr
+        + " \n#ENDDEFAULT plumed\n"
+      )
+  # Setup the formatter
+  formatfile = os.path.join(os.path.dirname(__file__), "PlumedFormatter.py")
+  valuedict, actions = {}, set()
+  plumed_formatter = load_formatter_from_file(
+    formatfile,
+    "PlumedFormatter",
+    keyword_dict=keyword_dict["cltools"],
+    input_name=name,
+    hasload=False,
+    broken=False,
+    auxinputs=[],
+    auxinputlines=[],
+    valuedict=valuedict,
+    actions=actions,
+    checkaction="",
+  )
+  return highlight(inpt, plumed_lexer, plumed_formatter)
 
-    with open( filename, "w+" ) as ofile: 
-       ninputs, nfail = processMarkdownString( inp, filename, plumedexe, plumed_names,
-               actions, ofile, jsondir, ghmarkdown, test_plumed_kwargs=test_plumed_kwargs )
-    return ninputs, nfail
 
-def processMarkdownString( inp, filename, plumedexe, plumed_names, actions, ofile,
-        jsondir="./", ghmarkdown=True, checkaction="ignore", checkactionkeywords=set({}),
-        *,test_plumed_kwargs={}) :
-    """
-       Process a string of markdown that contains LUMED input files using PlumedtoHTML
+def get_html(
+  inpt,
+  name,
+  outloc,
+  tested,
+  broken,
+  plumedexe,
+  usejson=None,
+  maxchecks=None,
+  actions=set({}),
+  ghmarkdown=True,
+  checkaction="",
+  checkactionkeywords=set({}),
+):
+  """
+  Generate the html representation of a PLUMED input file
 
-        Keyword arguments:
-        inp -- the string that contains the plumed input file
-        filename -- a name to use for the plumed inputs we create 
-        plumedexe -- a tuple of plumed executible names for testing plumed.
-        plumed_names -- the names of the plumed executibles to use in the badges
-        actions -- names of actions used in the plumed inputs in this markdown file
-        dirname -- the directory in which to find solution files
-        ofile -- the file on which to output the processed markdown
-        jsondir -- The directory in which to output the files containing the expansions of the shortcuts and the value dictionaries 
-        test_plumed_kwargs -- a dictionary of extra keywords to pass to the test_plumed utility, only "header" and "cmdTimeout" works
-    """
-    dirname = os.path.dirname(filename)
-    if dirname=="" : dirname = "." 
+  The html representation of a PLUMED input file has tooltips that
+  tell you what the keywords represent, a badge that shows whether the input
+  works and clickable labels that provide information about the quantities that
+  are calculated.  This function uses test_plumed to check if the plumed inpt can be parsed.
 
-    ninputs = 0
-    nfail = len(plumedexe)*[0]
-    inplumed = False
-    plumed_inp = ""
-    solutionfile = None
-    incomplete = False
-    usemermaid = ""
-    # Create a collection of cltools to regexp for
-    plumed_syntax = getPlumedSyntax( plumedexe )
-    cltoolregexps = []
-    clfileregexps = []
-    for key, data in plumed_syntax["cltools"].items() :
-        cltoolregexps.append(r"plumed\s+" + key )
-        cltoolregexps.append(r"plumed\s+--no-mpi\s+" + key )
-        cltoolregexps.append(r"plumed-runtime\s+" + key )
-        if data["inputtype"]=="file" :
-           clfileregexps.append( r"#TOOL\s*=\s*" + key )
+  Keyword arguments:
+  inpt -- A string containing the PLUMED input
+  name -- The name to use for this input in the html
+  outloc -- The location of the output files that were generated by test_plumed relative to the file that contains the input
+  tested -- The versions of plumed that were testd
+  broken -- The outcome of running test plumed on the input
+  plumedexe -- The plumed executibles that were used.  The first one is the one that should be used to create the input file annotations
+  usejson -- Bool that tells you whether or not to look for json files that are generated by plumed driver
+  maxchecks -- Maximum number of checks to perform on plumed input.  Set this to reduce computational expense
+  actions -- Set to store all the actions that have been used in the input
+  """
 
-    for line in inp.splitlines() :
-       # Detect and copy plumed input files 
-       if "```plumed" in line :
-          inplumed = True
-          plumed_inp = ""
-          solutionfile = None
-          incomplete = False
-          ninputs = ninputs + 1 
-    
-       # Test plumed input files that have been found in tutorial 
-       elif inplumed and "```" in line :
-          skipplumedfile, inplumed = False, False
-          # Create mermaid graphs from PLUMED inputs if this has been requested
-          if usemermaid!="" :
-             skipplumedfile, mermaidinpt = True, ""
-             if usemermaid=="value" :
-                mermaidinpt = get_mermaid( plumedexe[-1], plumed_inp, False,
-                        test_plumed_kwargs=test_plumed_kwargs)
-             elif usemermaid=="force" :
-                mermaidinpt = get_mermaid( plumedexe[-1], plumed_inp, True,
-                        test_plumed_kwargs=test_plumed_kwargs)
-             else :
-                raise RuntimeError(usemermaid + "is invalid instruction for use mermaid")
-             if ghmarkdown : ofile.write("```mermaid\n" + mermaidinpt + "\n```\n")
-             else : ofile.write("<pre class=\"mermaid\">\n" + mermaidinpt + "\n</pre>\n")
-             usemermaid = ""
+  # Check if we are looking for json files
+  if usejson is None:
+    searchjson = False
+    if not any(broken):
+      searchjson = True
+  else:
+    searchjson = usejson
 
-          # Check if this is the input for a command line tool and render accordingly
-          for tool in cltoolregexps :
-              if re.search( tool, plumed_inp ) :
-                 html = get_cltoolarg_html( plumed_inp, "cltool" + str(ninputs), plumedexe )
-                 if ghmarkdown : ofile.write( "{% raw %}\n" + html + "\n {% endraw %} \n" )
-                 else : ofile.write( html )
-                 skipplumedfile = True
+  # If we find the fill command then split up the input file to find the solution
+  inpt, incomplete = manage_incomplete_inputs(inpt)
 
-          # Check if this the input file for a command line tool and render accordingly
-          for tool in clfileregexps :
-              if re.search( tool, plumed_inp ) :
-                 html = get_cltoolfile_html( plumed_inp, "cltool" + str(ninputs), plumedexe )
-                 if ghmarkdown : ofile.write( "{% raw %}\n" + html + "\n {% endraw %} \n" )
-                 else : ofile.write( html )
-                 skipplumedfile = True 
+  # Create a list of all the auxiliary input files that are needed by the plumed input
+  inputfiles, inputfilelines, nreplicas = [], [], 1
+  for line in inpt.splitlines():
+    if "#SETTINGS" in line:
+      for word in line.split():
+        if "NREPLICAS=" in word:
+          nreplicas = int(word.replace("NREPLICAS=", ""))
+        elif "MOLFILE=" in word:
+          molfile = word.replace("MOLFILE=", "")
+          if os.path.isfile(molfile):
+            iff = open(molfile, "r")
+            content = iff.read()
+            iff.close()
+            inputfiles.append(molfile)
+            inputfilelines.append("1-5")
+            inputfilelines.append(
+              str(len(content.splitlines()) - 4) + "-" + str(len(content.splitlines()))
+            )
+          else:
+            warnings.warn(
+              "file " + molfile + " found in MOLFILE setting but file is not present"
+            )
+        elif "INPUTFILES=" in word:
+          for n in word.replace("INPUTFILES=", "").split(","):
+            if os.path.isfile(n):
+              inputfiles.append(n)
+            else:
+              raise Exception(
+                "file " + n + " found in list of INPUTFILES but file is not present"
+              )
+        elif "INPUTFILELINES=" in word:
+          inputfilelines = word.replace("INPUTFILELINES=", "").split(",")
 
-          if incomplete :
-                if solutionfile:
-                   # Read solution from solution file
-                   try:
-                      with open( dirname + "/" + solutionfile, "r" ) as sf:
-                         solution = sf.read()
-                         plumed_inp += "#SOLUTION \n" + solution
-                      solutionfile = dirname + "/" + solutionfile
-                   except:
-                      raise RuntimeError(f"error in opening {solutionfile} as solution"
-                                        f" for an incomplete input from file {filename}")
-                else:
-                   raise RuntimeError(f"an incomplete input from file {filename}"
-                                     " does not have its solution file")
-          # Create the full input for PlumedToHTML formatter 
-          else :
-                solutionfile = filename + "_working_" + str(ninputs) + ".dat"
-                with open( solutionfile, "w+" ) as sf:
-                   sf.write( plumed_inp )
-    
-          # Test whether the input solution can be parsed
-          if not skipplumedfile : 
-             success = len(plumedexe)*[False] 
-             for i in range(len(plumedexe)) : 
-                 if i==len(plumedexe)-1 : 
-                    # Json files are put in directory one up from us to ensure that
-                    # PlumedToHTML finds them when we do get_html (i.e. these will be in
-                    # the data directory where the calculation is run)
-                    if incomplete :
-                       success[i]=test_plumed(plumedexe[i], solutionfile, ghmarkdown=ghmarkdown,
-                               **test_plumed_kwargs)
-                    else :                        
-                       success[i]=test_plumed(plumedexe[i], solutionfile,
-                                                  printjson=True, jsondir=jsondir, ghmarkdown=ghmarkdown,
-                                                  **test_plumed_kwargs)
-                 else : 
-                    success[i]=test_plumed( plumedexe[i],
-                            solutionfile,
-                            ghmarkdown=ghmarkdown,
-                            **test_plumed_kwargs,)
-                 if(success[i]!=0 and success[i]!="custom") : nfail[i] = nfail[i] + 1
-             # Use PlumedToHTML to create the input with all the bells and whistles
-             html = get_html(plumed_inp,
-                               solutionfile,
-                               os.path.basename(solutionfile),
-                               plumed_names,
-                               success,
-                               plumedexe, 
-                               usejson=(not success[-1]),
-                               actions=actions,
-                               ghmarkdown=ghmarkdown,
-                               checkaction=checkaction,
-                               checkactionkeywords=checkactionkeywords )
-             # Print the html for the solution
-             if ghmarkdown : ofile.write( "{% raw %}\n" + html + "\n {% endraw %} \n" )
-             else : ofile.write( html )
-       # This finds us the solution file
-       elif inplumed and "#SOLUTIONFILE=" in line :
-          solutionfile=line.strip().replace("#SOLUTIONFILE=","")
-       elif inplumed and "#MERMAID=" in line :
-          usemermaid = line.replace("#MERMAID=","").strip()
-       elif inplumed :
-          if "__FILL__" in line :
-             incomplete = True
-          plumed_inp += line + "\n"
-       # Just copy any line that isn't part of a plumed input
-       elif not inplumed :
-          ofile.write( line + "\n")
+  # Check for include files
+  foundincludedfiles, srcdir = True, str(pathlib.PurePosixPath(name).parent)
+  if not any(broken) and "INCLUDE" in inpt:
+    foundincludedfiles, inpt = resolve_includes(
+      srcdir, inpt, nreplicas, foundincludedfiles
+    )
 
-    return ninputs, nfail 
+  # Check if there is a LOAD command in the input
+  found_load = "LOAD " in inpt
 
+  # Check for shortcut file and build the modified input to read the shortcuts
+  if os.path.exists(name + ".json") and searchjson:
+    # Read json file containing shortcuts
+    with open(name + ".json") as f:
+      try:
+        shortcutdata = json.load(f)
+      except json.JSONDecodeError as ve:
+        raise Exception("invalid json for shortcut dictionary", ve)
+    # Put everything in to resolve the expansions.  We call this function recursively just in case there are shortcuts in shortcuts
+    final_inpt = resolve_expansions(inpt, shortcutdata)
+  else:
+    final_inpt = inpt
+  # Remove the tempory files that we created
+  if os.path.exists(name + ".json"):
+    os.remove(name + ".json")
+
+  # Check for value dictionary to use to create labels
+  if os.path.exists(name + "_values.json") and searchjson:
+    with open(name + "_values.json") as f:
+      try:
+        valuedict = json.load(f)
+      except json.JSONDecodeError as ve:
+        raise Exception("invalid json for value dictionary", ve)
+  else:
+    valuedict = {}
+  # Remove the tempory files that we created
+  if os.path.exists(name + "_values.json"):
+    os.remove(name + "_values.json")
+
+  # Create the lexer that will generate the pretty plumed input
+  lexerfile = os.path.join(os.path.dirname(__file__), "PlumedLexer.py")
+  plumed_lexer = load_lexer_from_file(lexerfile, "PlumedLexer")
+  # Get the plumed syntax file
+  keyword_dict = getPlumedSyntax(plumedexe)
+  # Setup the formatter
+  formatfile = os.path.join(os.path.dirname(__file__), "PlumedFormatter.py")
+  plumed_formatter = load_formatter_from_file(
+    formatfile,
+    "PlumedFormatter",
+    keyword_dict=keyword_dict,
+    input_name=name,
+    hasload=found_load,
+    broken=any(broken),
+    auxinputs=inputfiles,
+    auxinputlines=inputfilelines,
+    valuedict=valuedict,
+    actions=actions,
+    checkaction=checkaction,
+  )
+
+  # Now generate html of input
+  html = '<div class="plumedInputContainer">\n'
+  html += '<div class="plumedpreheader">\n'
+  html += f'<div class="headerInfo" id="value_details_{name}"> Click on the labels of the actions for more information on what each action computes </div>\n'
+  html += '<div class="containerBadge">\n'
+  for i in range(len(tested)):
+    html += '<div class="headerBadge">'
+    btype = "passing-green.svg"
+    if broken[i]:
+      btype = "failed-red.svg"
+    # this if can be collapsed in a f'<a href="{"" if ghmarkdown else "../"}{outloc}.{plumedexe[i]}.stderr">'
+    # but like this it might be clearer, what do you think?
+    if ghmarkdown:
+      html += f'<a href="{outloc}.{plumedexe[i]}.stderr">'
+    else:
+      html += f'<a href="../{outloc}.{plumedexe[i]}.stderr">'
+    html += f'<img src="https://img.shields.io/badge/{tested[i]}-{btype}" alt="tested on{tested[i]}" />'
+    html += "</a>"
+    html += "</div>\n"
+
+  if found_load:
+    html += '<div class="headerBadge">'
+    html += '<img src="https://img.shields.io/badge/with-LOAD-yellow.svg" alt="tested on master" />'
+    html += "</div>\n"
+
+  if len(incomplete) > 0:
+    html += '<div class="headerBadge">'
+    html += f'<img class="toggler" src="https://img.shields.io/badge/{tested[-1]}-incomplete-yellow.svg" alt="tested on {tested[-1]}"'
+    html += f" onmouseup='toggleDisplay(\"{name}\")' onmousedown='toggleDisplay(\"{name}\")'/>"
+    html += "</div>\n"
+
+  html += "</div>\n</div>\n"
+
+  if len(incomplete) > 0:
+    # This creates the input with the __FILL__
+    html += '<div id="' + name + '_short">\n'
+    # html += highlight( final_inpt, plumed_lexer, HtmlFormatter() )
+    html += highlight(incomplete, plumed_lexer, plumed_formatter)
+    html += "</div>\n"
+    # This is the solution with the commplete input
+    html += '<div style="display:none;" id="' + name + '_long">'
+    plumed_formatter.egname = plumed_formatter.egname + "_sol"
+    # html += highlight( final_inpt, plumed_lexer, HtmlFormatter() )
+    html += highlight(final_inpt, plumed_lexer, plumed_formatter)
+    html += "</div>\n"
+  else:
+    # html += highlight( final_inpt, plumed_lexer, HtmlFormatter() )
+    html += highlight(final_inpt, plumed_lexer, plumed_formatter)
+  # close the html = '<div class="plumedInputContainer">\n'
+  html += "</div>\n"
+  # Now remove keywords that appear in examples
+  mykeywords = plumed_formatter.getCheckActionKeywords()
+  for key in mykeywords:
+    if key in checkactionkeywords:
+      checkactionkeywords.remove(key)
+
+  # Test output is valid parsable html
+  try:
+    etree.parse(StringIO(html), etree.HTMLParser(recover=False))
+  except etree.XMLSyntaxError as e:
+    raise Exception(
+      "Generated html is invalid as "
+      + str(e.error_log)
+      + " plumed input is \n\n"
+      + final_inpt
+    ) from e
+
+  # Check everything that is marked as a clickable value has something that will appear
+  # when you click it
+  nchecks, soup = 0, BeautifulSoup(html, "html.parser")
+  for val in soup.find_all("b"):
+    if "onclick" in val.attrs.keys():
+      nchecks, vallabels = nchecks + 1, val.attrs["onclick"].split('"')
+      if maxchecks is not None and nchecks > maxchecks:
+        warnings.warn(
+          "Only checked the html for the first "
+          + str(maxchecks)
+          + " of the "
+          + str(len(soup.find_all("b")))
+          + " labels in input file to reduce computational expense. The output is most likely fine but has not been checked as carefully as inputs with fewer values"
+        )
+        break
+      if not soup.find("span", {"id": vallabels[3]}):
+        warnings.warn(
+          "Problems with generated as label hidden box for label "
+          + vallabels[3]
+          + " is missing"
+        )
+      if not soup.find("div", {"id": "value_details_" + vallabels[1]}):
+        raise Exception(
+          "Generated html is invalid as there is no place to show data for "
+          + vallabels[1]
+        )
+
+  # Now check the togglers
+  nchecks = 0
+  for val in soup.find_all(attrs={"class": "toggler"}):
+    nchecks = nchecks + 1
+    if maxchecks is not None and nchecks > maxchecks:
+      warnings.warn(
+        "Only checked the html for the first "
+        + str(maxchecks)
+        + " of the "
+        + str(len(soup.find_all(attrs={"class": "toggler"})))
+        + " shortcuts in the input file to reduce computational expense. The output is most likely fine but has not been checked as carefully as inputs with fewer shortcuts"
+      )
+      break
+    if "onclick" in val.attrs.keys():
+      switchval = val.attrs["onclick"].split('"')[1]
+      if not soup.find("span", {"id": switchval + "_long"}):
+        raise Exception(
+          "Generated html is invalid as could not find " + switchval + "_long"
+        )
+      if not soup.find("span", {"id": switchval + "_short"}):
+        raise Exception(
+          "Generated html is invalid as could not find " + switchval + "_short"
+        )
+    elif "onmousedown" in val.attrs.keys():
+      switchval = val.attrs["onmousedown"].split('"')[1]
+      if not soup.find("div", {"id": switchval + "_long"}):
+        raise Exception(
+          "Generated html is invalid as could not find " + switchval + "_long"
+        )
+      if not soup.find("div", {"id": switchval + "_short"}):
+        raise Exception(
+          "Generated html is invalid as could not find " + switchval + "_short"
+        )
+    else:
+      raise Exception("Could not find toggler command for " + val)
+  return html
+
+
+def get_mermaid(executible, inpt, force, *, test_plumed_kwargs={}):
+  """
+  Generate the mermaid graph showing how data passes through PLUMED input file
+
+  Keyword arguments:
+  inpt -- A string containing the PLUMED input
+  force -- Bool that if true ensures we show the graph for the backwards pass through the action list
+  test_plumed_kwargs -- a dictionary of extra keywords to pass to the test_plumed utility, useful for passing an"header"
+  """
+  # Write the plumed input to a file
+  iff = open("mermaid_plumed.dat", "w+")
+  iff.write(inpt + "\n")
+  iff.close()
+  # Now check the input is OK
+  broken = test_plumed(executible, "mermaid_plumed.dat", **test_plumed_kwargs)
+  if broken != 0:
+    raise Exception("invalid plumed input file -- cannot create mermaid graph")
+  # Run mermaid
+  cmd = [
+    executible,
+    "show_graph",
+    "--plumed",
+    "mermaid_plumed.dat",
+    "--out",
+    "mermaid.md",
+  ]
+  if force:
+    cmd.append("--force")
+  plumed_out = subprocess.run(
+    cmd, text=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
+  )
+  if plumed_out.returncode != 0:
+    raise Exception("error running plumed show_graph")
+  mf = open("mermaid.md")
+  mermaid = mf.read()
+  mf.close()
+  # Remove stuff that was created
+  os.remove("mermaid_plumed.dat")
+  os.remove("mermaid.md")
+  return mermaid
+
+
+def resolve_includes(srcdir, inpt, nreplicas, foundfiles):
+  if not foundfiles or "INCLUDE" not in inpt:
+    return foundfiles, inpt
+
+  incontinuation, final_inpt, clines = False, "", ""
+  for line in inpt.splitlines():
+    # Empty the buffer that holds the input for this line if we are not in a continuation
+    if not incontinuation:
+      clines = ""
+    # Check for start and end of continuation
+    if "..." in line and incontinuation:
+      incontinuation = False
+    elif "..." in line and not incontinuation:
+      incontinuation = True
+    # Build up everythign that forms part of input for one action
+    clines += line + "\n"
+    # Just continue if we don't have the full line
+    if incontinuation:
+      continue
+
+    # Now check if there is an include
+    if "INCLUDE" in clines:
+      # Split up the line
+      iscomment, filename = False, ""
+      for w in clines.split():
+        if "#" in w and filename == "":
+          iscomment = True
+        elif "FILE=" in w:
+          filename = w.replace("FILE=", "")
+      if iscomment:
+        final_inpt += clines
+        continue
+      if filename == "":
+        raise Exception("could not find name of file to include")
+      if not os.path.exists(filename):
+        foundfiles = False
+      splitname = filename.rsplit(".", 1)
+      if len(splitname) > 2:
+        raise Exception("cannot deal with included file named " + filename)
+
+      final_inpt += (
+        "#SHORTCUT "
+        + filename
+        + "\n"
+        + clines
+        + "#EXPANSION "
+        + filename
+        + "\n# The command:\n"
+      )
+      final_inpt += (
+        "# "
+        + clines
+        + "# ensures PLUMED loads the contents of the file called "
+        + filename
+        + "\n"
+      )
+      if nreplicas > 1 and os.path.exists(
+        srcdir + "/" + splitname[0] + ".0." + splitname[1]
+      ):
+        final_inpt += "# There are different versions of this file on each replica\n"
+        for i in range(nreplicas):
+          f = open(
+            srcdir + "/" + splitname[0] + "." + str(i) + "." + splitname[1],
+            "r",
+          )
+          include_contents = f.read()
+          f.close()
+          final_inpt += (
+            "# The contents of the version of this file ("
+            + splitname[0]
+            + "."
+            + str(i)
+            + "."
+            + splitname[1]
+            + ") on replica "
+            + str(i)
+            + " is shown below.\n"
+          )
+          foundfiles, parsed_inpt = resolve_includes(
+            srcdir, include_contents, nreplicas, foundfiles
+          )
+          final_inpt += parsed_inpt
+        final_inpt += "#(click the red comment to hide this expanded text).\n"
+        if final_inpt.endswith("\n"):
+          final_inpt += "#ENDEXPANSION " + filename + "\n"
+        else:
+          final_inpt += "\n#ENDEXPANSION " + filename + "\n"
+      else:
+        f = open(srcdir + "/" + filename, "r")
+        include_contents = f.read()
+        f.close()
+        final_inpt += "# The contents of this file are shown below (click the red comment to hide them).\n"
+        foundfiles, parsed_inpt = resolve_includes(
+          srcdir, include_contents, nreplicas, foundfiles
+        )
+        if parsed_inpt.endswith("\n"):
+          final_inpt += parsed_inpt + "#ENDEXPANSION " + filename + "\n"
+        else:
+          final_inpt += parsed_inpt + "\n#ENDEXPANSION " + filename + "\n"
+    else:
+      final_inpt += clines
+  return foundfiles, final_inpt
+
+
+def resolve_expansions(inpt, jsondata):
+  # Stop expanding if we have reached the bottom
+  if len(jsondata.keys()) == 0:
+    return inpt + "\n"
+
+  incontinuation, final_inpt, clines = False, "", ""
+  for line in inpt.splitlines():
+    # Empty the buffer that holds the input for this line if we are not in a continuation
+    if not incontinuation:
+      clines = ""
+    # Check for start and end of continuation
+    if "..." in line and incontinuation:
+      incontinuation = False
+    elif "..." in line and not incontinuation:
+      incontinuation = True
+    # Build up everythign that forms part of input for one action
+    clines += line + "\n"
+    # Just continue if we don't have the full line
+    if incontinuation:
+      continue
+    # Find the label of this line if it has one
+    label = ""
+    if "LABEL=" in clines:
+      afterlab = clines[clines.index("LABEL=") + len("LABEL=") :]
+      label = afterlab.split()[0]
+    elif clines.find(":"):
+      label = clines.split(":")[0].strip()
+    if len(label) > 0 and label in jsondata:
+      if "expansion" in jsondata[label]:
+        final_inpt += "#SHORTCUT " + label + "\n"
+        if "defaults" in jsondata[label]:
+          final_inpt += "#NODEFAULT " + label + "\n" + clines
+        else:
+          final_inpt += clines
+        # Add long version with defaults to input
+        if "defaults" in jsondata[label] and "..." in clines:
+          alldat, bef = clines.split("\n"), ""
+          for i in range(len(alldat) - 2):
+            bef += alldat[i] + "\n"
+          final_inpt += (
+            "#DEFAULT "
+            + label
+            + "\n"
+            + bef
+            + jsondata[label]["defaults"]
+            + "\n"
+            + alldat[-2]
+            + "\n#ENDDEFAULT "
+            + label
+            + "\n"
+          )
+        elif "defaults" in jsondata[label]:
+          final_inpt += (
+            "#DEFAULT "
+            + label
+            + "\n"
+            + clines.strip()
+            + " "
+            + jsondata[label]["defaults"]
+            + "\n#ENDDEFAULT "
+            + label
+            + "\n"
+          )
+        # Add stuff for long version of input in collapsible
+        final_inpt += "#EXPANSION " + label + "\n# PLUMED interprets the command:\n"
+        for gline in clines.splitlines():
+          final_inpt += "# " + gline + "\n"
+        local_json = dict(jsondata[label])
+        local_json.pop("expansion", "defaults")
+        final_inpt += (
+          "# as follows (Click the red comment above to revert to the short version of the input):\n"
+          + resolve_expansions(jsondata[label]["expansion"], local_json)
+        )
+        final_inpt += "#ENDEXPANSION " + label + "\n"
+      elif "defaults" in jsondata[label]:
+        final_inpt += "#NODEFAULT " + label + "\n" + clines
+        if "..." in clines:
+          alldat, bef = clines.split("\n"), ""
+          for i in range(len(alldat) - 2):
+            bef += alldat[i] + "\n"
+          final_inpt += (
+            "#DEFAULT "
+            + label
+            + "\n"
+            + bef
+            + jsondata[label]["defaults"]
+            + "\n"
+            + alldat[-2]
+            + "\n#ENDDEFAULT "
+            + label
+            + "\n"
+          )
+        else:
+          final_inpt += (
+            "#DEFAULT "
+            + label
+            + "\n"
+            + clines.strip()
+            + " "
+            + jsondata[label]["defaults"]
+            + "\n#ENDDEFAULT "
+            + label
+            + "\n"
+          )
+    else:
+      final_inpt += clines
+  return final_inpt
+
+
+def get_html_header():
+  """
+  Get the information that needs to go in the header of the html file to make the interactive PLUMED
+  inputs work
+  """
+  headerfilename = os.path.join(os.path.dirname(__file__), "assets/header.html")
+  hfile = open(headerfilename)
+  codes = hfile.read()
+  hfile.close()
+  return codes
+
+
+def get_javascript():
+  """
+  Get the javascript from the header of the html file to make the interactive PLUMED inputs work
+  """
+  inscript, fullheader, jscode = False, get_html_header().splitlines(), ""
+  for line in fullheader:
+    if "</script>" in line and inscript:
+      inscript = False
+      break
+    elif "<script>" in line:
+      inscript = True
+    elif inscript:
+      if (
+        ("<style>" in line)
+        or ("</style>" in line)
+        or ("<script>" in line)
+        or ("</script>" in line)
+      ):
+        raise Exception("found invalid html tag in javascript line " + line)
+      jscode += line + "\n"
+  return jscode
+
+
+def get_css():
+  """
+  Get the css from the header of the html file to make the interactive PLUMED inputs work
+  """
+  inscript, fullheader, css = False, get_html_header().splitlines(), ""
+  for line in fullheader:
+    if "</style>" in line and inscript:
+      inscript = False
+      break
+    elif "<style>" in line:
+      inscript = True
+    elif inscript:
+      if (
+        ("<style>" in line)
+        or ("</style>" in line)
+        or ("<script>" in line)
+        or ("</script>" in line)
+      ):
+        raise Exception("found invalid html tag in css line " + line)
+      css += line + "\n"
+  return css
+
+
+def compare_to_reference(output, reference):
+  """
+  Compare the html that is output by PlumedFormatter with the reference data.  This function is used for
+  testing PlumedToHMTL
+  """
+  soup = BeautifulSoup(output, "html.parser")
+  # Check that comments in PLUMED input have been detected correctly
+  if "comment" in reference.keys():
+    soup_comments = soup.find_all(attrs={"class": "comment"})
+    if len(soup_comments) != len(reference["comments"]):
+      return False
+    for i in range(len(soup_comments)):
+      if soup_comments[i].get_text() != reference["comments"][i]:
+        return False
+
+  print("Comments fine")
+  # Check that everything that should be rendered as a tooltip has been rendered as a tooltip
+  # This is action names and keywords
+  if "tooltips" in reference.keys():
+    soup_tooltips = soup.find_all(attrs={"class": "plumedtooltip"})
+    print("CHECK TOOLTIP", soup_tooltips)
+    print("TOOLTIP NUMBER CORRECT", len(soup_tooltips), len(reference["tooltips"]))
+    if len(soup_tooltips) != len(reference["tooltips"]):
+      print("REFERENCE tooltips: ", reference["tooltips"])
+      print("FOUND tooltips:     ", [x.contents[0] for x in soup_tooltips])
+      return False
+    for i in range(len(soup_tooltips)):
+      print("COMPARISON", soup_tooltips[i].contents[0], reference["tooltips"][i])
+      if soup_tooltips[i].contents[0] != reference["tooltips"][i]:
+        return False
+
+  return True
+
+
+def processMarkdown(
+  filename,
+  plumedexe,
+  plumed_names,
+  actions,
+  jsondir="./",
+  ghmarkdown=True,
+  *,
+  test_plumed_kwargs={},
+):
+  """
+  Process a markdown file that contains PLUMED input files using PlumedtoHTML
+
+  Keyword arguments:
+  filename -- the name of the markdown file
+  plumedexe -- a tuple of plumed executible names for testing plumed.
+  plumed_names -- the names of the plumed executibles to use in the badges
+  actions -- names of actions used in the plumed inputs in this markdown file
+  jsondir -- The directory in which to output the files containing the expansions of the shortcuts and the value dictionaries
+  test_plumed_kwargs -- a dictionary of extra keywords to pass to the test_plumed utility, only "header" and "cmdTimeout" works
+  """
+  if not os.path.exists(filename):
+    raise RuntimeError("Found no file called " + filename + " in lesson")
+
+  with open(filename, "r") as f:
+    inp = f.read()
+
+  with open(filename, "w+") as ofile:
+    ninputs, nfail = processMarkdownString(
+      inp,
+      filename,
+      plumedexe,
+      plumed_names,
+      actions,
+      ofile,
+      jsondir,
+      ghmarkdown,
+      test_plumed_kwargs=test_plumed_kwargs,
+    )
+  return ninputs, nfail
+
+
+def processMarkdownString(
+  inp,
+  filename,
+  plumedexe,
+  plumed_names,
+  actions,
+  ofile,
+  jsondir="./",
+  ghmarkdown=True,
+  checkaction="ignore",
+  checkactionkeywords=set({}),
+  *,
+  test_plumed_kwargs={},
+):
+  """
+  Process a string of markdown that contains LUMED input files using PlumedtoHTML
+
+   Keyword arguments:
+   inp -- the string that contains the plumed input file
+   filename -- a name to use for the plumed inputs we create
+   plumedexe -- a tuple of plumed executible names for testing plumed.
+   plumed_names -- the names of the plumed executibles to use in the badges
+   actions -- names of actions used in the plumed inputs in this markdown file
+   dirname -- the directory in which to find solution files
+   ofile -- the file on which to output the processed markdown
+   jsondir -- The directory in which to output the files containing the expansions of the shortcuts and the value dictionaries
+   test_plumed_kwargs -- a dictionary of extra keywords to pass to the test_plumed utility, only "header" and "cmdTimeout" works
+  """
+  dirname = os.path.dirname(filename)
+  if dirname == "":
+    dirname = "."
+
+  ninputs = 0
+  nfail = len(plumedexe) * [0]
+  inplumed = False
+  plumed_inp = ""
+  solutionfile = None
+  incomplete = False
+  usemermaid = ""
+  # Create a collection of cltools to regexp for
+  plumed_syntax = getPlumedSyntax(plumedexe)
+  cltoolregexps = []
+  clfileregexps = []
+  for key, data in plumed_syntax["cltools"].items():
+    cltoolregexps.append(r"plumed\s+" + key)
+    cltoolregexps.append(r"plumed\s+--no-mpi\s+" + key)
+    cltoolregexps.append(r"plumed-runtime\s+" + key)
+    if data["inputtype"] == "file":
+      clfileregexps.append(r"#TOOL\s*=\s*" + key)
+
+  for line in inp.splitlines():
+    # Detect and copy plumed input files
+    if "```plumed" in line:
+      inplumed = True
+      plumed_inp = ""
+      solutionfile = None
+      incomplete = False
+      ninputs = ninputs + 1
+
+    # Test plumed input files that have been found in tutorial
+    elif inplumed and "```" in line:
+      skipplumedfile, inplumed = False, False
+      # Create mermaid graphs from PLUMED inputs if this has been requested
+      if usemermaid != "":
+        skipplumedfile, mermaidinpt = True, ""
+        if usemermaid == "value":
+          mermaidinpt = get_mermaid(
+            plumedexe[-1],
+            plumed_inp,
+            False,
+            test_plumed_kwargs=test_plumed_kwargs,
+          )
+        elif usemermaid == "force":
+          mermaidinpt = get_mermaid(
+            plumedexe[-1],
+            plumed_inp,
+            True,
+            test_plumed_kwargs=test_plumed_kwargs,
+          )
+        else:
+          raise RuntimeError(usemermaid + "is invalid instruction for use mermaid")
+        if ghmarkdown:
+          ofile.write("```mermaid\n" + mermaidinpt + "\n```\n")
+        else:
+          ofile.write('<pre class="mermaid">\n' + mermaidinpt + "\n</pre>\n")
+        usemermaid = ""
+
+      # Check if this is the input for a command line tool and render accordingly
+      for tool in cltoolregexps:
+        if re.search(tool, plumed_inp):
+          html = get_cltoolarg_html(plumed_inp, "cltool" + str(ninputs), plumedexe)
+          if ghmarkdown:
+            ofile.write("{% raw %}\n" + html + "\n {% endraw %} \n")
+          else:
+            ofile.write(html)
+          skipplumedfile = True
+
+      # Check if this the input file for a command line tool and render accordingly
+      for tool in clfileregexps:
+        if re.search(tool, plumed_inp):
+          html = get_cltoolfile_html(plumed_inp, "cltool" + str(ninputs), plumedexe)
+          if ghmarkdown:
+            ofile.write("{% raw %}\n" + html + "\n {% endraw %} \n")
+          else:
+            ofile.write(html)
+          skipplumedfile = True
+
+      if incomplete:
+        if solutionfile:
+          # Read solution from solution file
+          try:
+            with open(dirname + "/" + solutionfile, "r") as sf:
+              solution = sf.read()
+              plumed_inp += "#SOLUTION \n" + solution
+            solutionfile = dirname + "/" + solutionfile
+          except Exception as _:
+            raise RuntimeError(
+              f"error in opening {solutionfile} as solution"
+              f" for an incomplete input from file {filename}"
+            )
+        else:
+          raise RuntimeError(
+            f"an incomplete input from file {filename} does not have its solution file"
+          )
+      # Create the full input for PlumedToHTML formatter
+      else:
+        solutionfile = filename + "_working_" + str(ninputs) + ".dat"
+        with open(solutionfile, "w+") as sf:
+          sf.write(plumed_inp)
+
+      # Test whether the input solution can be parsed
+      if not skipplumedfile:
+        success = len(plumedexe) * [False]
+        for i in range(len(plumedexe)):
+          if i == len(plumedexe) - 1:
+            # Json files are put in directory one up from us to ensure that
+            # PlumedToHTML finds them when we do get_html (i.e. these will be in
+            # the data directory where the calculation is run)
+            if incomplete:
+              success[i] = test_plumed(
+                plumedexe[i],
+                solutionfile,
+                ghmarkdown=ghmarkdown,
+                **test_plumed_kwargs,
+              )
+            else:
+              success[i] = test_plumed(
+                plumedexe[i],
+                solutionfile,
+                printjson=True,
+                jsondir=jsondir,
+                ghmarkdown=ghmarkdown,
+                **test_plumed_kwargs,
+              )
+          else:
+            success[i] = test_plumed(
+              plumedexe[i],
+              solutionfile,
+              ghmarkdown=ghmarkdown,
+              **test_plumed_kwargs,
+            )
+          if success[i] != 0 and success[i] != "custom":
+            nfail[i] = nfail[i] + 1
+        # Use PlumedToHTML to create the input with all the bells and whistles
+        html = get_html(
+          plumed_inp,
+          solutionfile,
+          os.path.basename(solutionfile),
+          plumed_names,
+          success,
+          plumedexe,
+          usejson=(not success[-1]),
+          actions=actions,
+          ghmarkdown=ghmarkdown,
+          checkaction=checkaction,
+          checkactionkeywords=checkactionkeywords,
+        )
+        # Print the html for the solution
+        if ghmarkdown:
+          ofile.write("{% raw %}\n" + html + "\n {% endraw %} \n")
+        else:
+          ofile.write(html)
+    # This finds us the solution file
+    elif inplumed and "#SOLUTIONFILE=" in line:
+      solutionfile = line.strip().replace("#SOLUTIONFILE=", "")
+    elif inplumed and "#MERMAID=" in line:
+      usemermaid = line.replace("#MERMAID=", "").strip()
+    elif inplumed:
+      if "__FILL__" in line:
+        incomplete = True
+      plumed_inp += line + "\n"
+    # Just copy any line that isn't part of a plumed input
+    elif not inplumed:
+      ofile.write(line + "\n")
+
+  return ninputs, nfail

--- a/src/PlumedToHTML/__init__.py
+++ b/src/PlumedToHTML/__init__.py
@@ -1,1 +1,31 @@
-from .PlumedToHTML import test_plumed, test_and_get_html, get_html, get_html_header, compare_to_reference, get_mermaid, processMarkdown, processMarkdownString, get_javascript, get_css, getPlumedSyntax, get_cltoolarg_html, get_cltoolfile_html
+from .PlumedToHTML import (
+  test_plumed,
+  test_and_get_html,
+  get_html,
+  get_html_header,
+  compare_to_reference,
+  get_mermaid,
+  processMarkdown,
+  processMarkdownString,
+  get_javascript,
+  get_css,
+  getPlumedSyntax,
+  get_cltoolarg_html,
+  get_cltoolfile_html,
+)
+
+__all__ = [
+  "test_plumed",
+  "test_and_get_html",
+  "get_html",
+  "get_html_header",
+  "compare_to_reference",
+  "get_mermaid",
+  "processMarkdown",
+  "processMarkdownString",
+  "get_javascript",
+  "get_css",
+  "getPlumedSyntax",
+  "get_cltoolarg_html",
+  "get_cltoolfile_html",
+]

--- a/tests/test_cllexing.py
+++ b/tests/test_cllexing.py
@@ -1,39 +1,47 @@
 from unittest import TestCase
 
-import os
 import json
 from io import StringIO
 from pygments.formatters import HtmlFormatter
 
 import PlumedToHTML
 
+
 class TestPlumedLexer(TestCase):
-   def lexerTestTemplate(self,file:str, lexerFunc, htmlFunction) :
-       # Open the json file and read it in
-      with open(file) as f:
-         tests = json.load(f)
+  def lexerTestTemplate(self, file: str, lexerFunc, htmlFunction):
+    # Open the json file and read it in
+    with open(file) as f:
+      tests = json.load(f)
 
-      # Setup an HTML formatter
-      formatter = HtmlFormatter()  
+    # Setup an HTML formatter
+    formatter = HtmlFormatter()
 
-      # Now run over all the inputs in the json
-      for item in tests["regtests"] :
-         with self.subTest(item=item,msg=item["input"]):
-            tokensource = list(lexerFunc().get_tokens(item["input"]))
-            output = StringIO()
-            formatter.format( tokensource, output )
-            data = {}
-            data["out"] = output.getvalue() 
-            print( f'**INPUT:"{item["input"]}"' )
-            print( json.dumps( data, indent=3 ) )
-            self.assertEqual( output.getvalue(),item["output"] )
-            out = htmlFunction( item["input"], "plinp" + str(item["index"]), ("plumed",) )
-            self.assertTrue( PlumedToHTML.compare_to_reference( out, item ) )
+    # Now run over all the inputs in the json
+    for item in tests["regtests"]:
+      with self.subTest(item=item, msg=item["input"]):
+        tokensource = list(lexerFunc().get_tokens(item["input"]))
+        output = StringIO()
+        formatter.format(tokensource, output)
+        data = {}
+        data["out"] = output.getvalue()
+        print(f'**INPUT:"{item["input"]}"')
+        print(json.dumps(data, indent=3))
+        self.assertEqual(output.getvalue(), item["output"])
+        out = htmlFunction(item["input"], "plinp" + str(item["index"]), ("plumed",))
+        self.assertTrue(PlumedToHTML.compare_to_reference(out, item))
 
-   def testCLtoolLexer(self) :
-      from PlumedToHTML.PlumedCLtoolLexer import PlumedCLtoolLexer 
-      self.lexerTestTemplate("tdata/cltooltests.json",PlumedCLtoolLexer, PlumedToHTML.get_cltoolarg_html)
-   
-   def testCLFileLexer(self) :
-      from PlumedToHTML.PlumedCLFileLexer import PlumedCLFileLexer 
-      self.lexerTestTemplate("tdata/clfiletests.json",PlumedCLFileLexer, PlumedToHTML.get_cltoolfile_html)
+  def testCLtoolLexer(self):
+    from PlumedToHTML.PlumedCLtoolLexer import PlumedCLtoolLexer
+
+    self.lexerTestTemplate(
+      "tdata/cltooltests.json", PlumedCLtoolLexer, PlumedToHTML.get_cltoolarg_html
+    )
+
+  def testCLFileLexer(self):
+    from PlumedToHTML.PlumedCLFileLexer import PlumedCLFileLexer
+
+    self.lexerTestTemplate(
+      "tdata/clfiletests.json",
+      PlumedCLFileLexer,
+      PlumedToHTML.get_cltoolfile_html,
+    )

--- a/tests/test_clmarkdown.py
+++ b/tests/test_clmarkdown.py
@@ -1,63 +1,73 @@
 from unittest import TestCase
 
-import os
 import json
 import PlumedToHTML
-from bs4 import BeautifulSoup
+
 
 class TestPlumedToHTML(TestCase):
-   def testBasicOutput(self) :
-       # Run over the checks on the command line tools
-       f = open("tdata/cltooltests.json")
-       cltests = json.load(f)
-       f.close()
+  def testBasicOutput(self):
+    # Run over the checks on the command line tools
+    f = open("tdata/cltooltests.json")
+    cltests = json.load(f)
+    f.close()
 
-       # Now run over all the inputs in the json
-       n=1
-       for item in cltests["regtests"] :
-           with self.subTest(item=item):
-                print("INPUT", item["index"], item["input"] )
-                with open("testmarkdown" + str(n) +".md", "w") as of :
-                     of.write("# TEST MARKDOWN \n\n")
-                     of.write("Some text before DISTANCE \n")
-                     of.write("```plumed`\n")
-                     of.write( item["input"] + "\n")
-                     of.write("```\n")
-                     of.write("Some text after \n")
-                actions = set()
-                PlumedToHTML.processMarkdown( "testmarkdown" + str(n) +".md", ("plumed",), ("master",), actions )
-                with open("testmarkdown" + str(n) +".md", "r") as f : inp = f.read()
-                out, inhtml = "", False
-                for line in inp.splitlines() :
-                    if inhtml and "{% endraw %}" in line : inhtml = False
-                    elif inhtml : out += line + "\n"
-                    elif "{% raw %}" in line : inhtml = True
-                self.assertTrue( PlumedToHTML.compare_to_reference( out, item ) )
-                n=n+1
+    # Now run over all the inputs in the json
+    n = 1
+    for item in cltests["regtests"]:
+      with self.subTest(item=item):
+        print("INPUT", item["index"], item["input"])
+        with open("testmarkdown" + str(n) + ".md", "w") as of:
+          of.write("# TEST MARKDOWN \n\n")
+          of.write("Some text before DISTANCE \n")
+          of.write("```plumed`\n")
+          of.write(item["input"] + "\n")
+          of.write("```\n")
+          of.write("Some text after \n")
+        actions = set()
+        PlumedToHTML.processMarkdown(
+          "testmarkdown" + str(n) + ".md", ("plumed",), ("master",), actions
+        )
+        with open("testmarkdown" + str(n) + ".md", "r") as f:
+          inp = f.read()
+        out, inhtml = "", False
+        for line in inp.splitlines():
+          if inhtml and "{% endraw %}" in line:
+            inhtml = False
+          elif inhtml:
+            out += line + "\n"
+          elif "{% raw %}" in line:
+            inhtml = True
+        self.assertTrue(PlumedToHTML.compare_to_reference(out, item))
+        n = n + 1
 
-       # Run over the the checks on the command line input files
-       f = open("tdata/clfiletests.json")
-       filetests = json.load(f)
-       f.close()
+    # Run over the the checks on the command line input files
+    f = open("tdata/clfiletests.json")
+    filetests = json.load(f)
+    f.close()
 
-       for item in filetests["regtests"] :
-           with self.subTest(item=item):
-                print("INPUT", item["index"], item["input"] )
-                with open("testmarkdown" + str(n) +".md", "w") as of :
-                     of.write("# TEST MARKDOWN \n\n")
-                     of.write("Some text before DISTANCE \n")
-                     of.write("```plumed`\n")
-                     of.write( item["input"] + "\n")
-                     of.write("```\n")
-                     of.write("Some text after \n")
-                actions = set()
-                PlumedToHTML.processMarkdown( "testmarkdown" + str(n) +".md", ("plumed",), ("master",), actions )
-                with open("testmarkdown" + str(n) +".md", "r") as f : inp = f.read()
-                out, inhtml = "", False
-                for line in inp.splitlines() :
-                    if inhtml and "{% endraw %}" in line : inhtml = False
-                    elif inhtml : out += line + "\n"
-                    elif "{% raw %}" in line : inhtml = True
-                self.assertTrue( PlumedToHTML.compare_to_reference( out, item ) )
-                n=n+1
-
+    for item in filetests["regtests"]:
+      with self.subTest(item=item):
+        print("INPUT", item["index"], item["input"])
+        with open("testmarkdown" + str(n) + ".md", "w") as of:
+          of.write("# TEST MARKDOWN \n\n")
+          of.write("Some text before DISTANCE \n")
+          of.write("```plumed`\n")
+          of.write(item["input"] + "\n")
+          of.write("```\n")
+          of.write("Some text after \n")
+        actions = set()
+        PlumedToHTML.processMarkdown(
+          "testmarkdown" + str(n) + ".md", ("plumed",), ("master",), actions
+        )
+        with open("testmarkdown" + str(n) + ".md", "r") as f:
+          inp = f.read()
+        out, inhtml = "", False
+        for line in inp.splitlines():
+          if inhtml and "{% endraw %}" in line:
+            inhtml = False
+          elif inhtml:
+            out += line + "\n"
+          elif "{% raw %}" in line:
+            inhtml = True
+        self.assertTrue(PlumedToHTML.compare_to_reference(out, item))
+        n = n + 1

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,31 +1,37 @@
 from unittest import TestCase
 
-import os
 import json
 import PlumedToHTML
 from bs4 import BeautifulSoup
 
-class TestPlumedToHTML(TestCase):
-   def testBasicOutput(self) :
-       # Open the json file and read it in
-       f = open("tdata/tests.json")
-       tests = json.load(f)
-       f.close()
 
-       # Now run over all the inputs in the json
-       for item in tests["regtests"] :
-           with self.subTest(item=item):
-                print("INPUT", item["index"], item["input"] )
-                actions = set({})
-                out = PlumedToHTML.test_and_get_html( item["input"], "plinp" + str(item["index"]), actions=actions )
-                self.assertTrue( actions==set(item["actions"]) ) 
-                self.assertTrue( PlumedToHTML.compare_to_reference( out, item ) )
-                soup = BeautifulSoup( out, "html.parser" )
-                # Check the badges 
-                out_badges = soup.find_all("img")
-                self.assertTrue( len(out_badges)==len(item["badges"]) )
-                for i in range(len(out_badges)) :
-                    if item["badges"][i]=="pass" : self.assertTrue( out_badges[i].attrs["src"].find("passing")>0 ) 
-                    elif item["badges"][i]=="fail" : self.assertTrue( out_badges[i].attrs["src"].find("failed")>0 )
-                    elif item["badges"][i]=="load" : self.assertTrue( out_badges[i].attrs["src"].find("with-LOAD")>0 )
-                    elif item["badges"][i]=="incomplete" : self.assertTrue( out_badges[i].attrs["src"].find("incomplete")>0 )
+class TestPlumedToHTML(TestCase):
+  def testBasicOutput(self):
+    # Open the json file and read it in
+    f = open("tdata/tests.json")
+    tests = json.load(f)
+    f.close()
+
+    # Now run over all the inputs in the json
+    for item in tests["regtests"]:
+      with self.subTest(item=item):
+        print("INPUT", item["index"], item["input"])
+        actions = set({})
+        out = PlumedToHTML.test_and_get_html(
+          item["input"], "plinp" + str(item["index"]), actions=actions
+        )
+        self.assertTrue(actions == set(item["actions"]))
+        self.assertTrue(PlumedToHTML.compare_to_reference(out, item))
+        soup = BeautifulSoup(out, "html.parser")
+        # Check the badges
+        out_badges = soup.find_all("img")
+        self.assertTrue(len(out_badges) == len(item["badges"]))
+        for i in range(len(out_badges)):
+          if item["badges"][i] == "pass":
+            self.assertTrue(out_badges[i].attrs["src"].find("passing") > 0)
+          elif item["badges"][i] == "fail":
+            self.assertTrue(out_badges[i].attrs["src"].find("failed") > 0)
+          elif item["badges"][i] == "load":
+            self.assertTrue(out_badges[i].attrs["src"].find("with-LOAD") > 0)
+          elif item["badges"][i] == "incomplete":
+            self.assertTrue(out_badges[i].attrs["src"].find("incomplete") > 0)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,45 +1,60 @@
 from unittest import TestCase
 
-import os
 import json
 from io import StringIO
-import subprocess
 from bs4 import BeautifulSoup
 from PlumedToHTML.PlumedLexer import PlumedLexer
 from PlumedToHTML.PlumedFormatter import PlumedFormatter
 from PlumedToHTML import compare_to_reference
 from PlumedToHTML import getPlumedSyntax
 
+
 class TestPlumedFormatter(TestCase):
-   def testSimple(self) :
-       # Open the json file and read it in
-       f = open("tdata/formattests.json")
-       tests = json.load(f)
-       f.close()
+  def testSimple(self):
+    # Open the json file and read it in
+    f = open("tdata/formattests.json")
+    tests = json.load(f)
+    f.close()
 
-       # Get the plumed syntax file
-       keydict = getPlumedSyntax( ("plumed",) )
+    # Get the plumed syntax file
+    keydict = getPlumedSyntax(("plumed",))
 
-       # Setup a plumed formatter
-       f = PlumedFormatter( keyword_dict=keydict, input_name="testout", hasload=False, broken=False, actions=set({}), valuedict=dict({}), auxinputs=[], auxinputlines=[], checkaction="" )
+    # Setup a plumed formatter
+    f = PlumedFormatter(
+      keyword_dict=keydict,
+      input_name="testout",
+      hasload=False,
+      broken=False,
+      actions=set({}),
+      valuedict=dict({}),
+      auxinputs=[],
+      auxinputlines=[],
+      checkaction="",
+    )
 
-       # Now run over all the inputs in the json
-       for item in tests["regtests"] :
-           with self.subTest(item=item): 
-               print("INPUT", item["input"] )
-               tokensource = list(PlumedLexer().get_tokens(item["input"]))
-               output = StringIO() 
-               f.format( tokensource, output )
-               # Check for clickable labels
-               self.assertTrue( compare_to_reference( output.getvalue(), item ) )
-               soup = BeautifulSoup( output.getvalue(), "html.parser" )
-               for val in soup.find_all("b") :
-                   if "onclick" in val.attrs.keys() : 
-                      vallabel = val.attrs["onclick"].split("\"")[3]
-                      self.assertTrue( soup.find("span", {"id": vallabel}) )
-               # Check for switching cells
-               for val in soup.find_all(attrs={'class': 'toggler'}) :
-                   if "onclick" in val.attrs.keys() :
-                      switchval = val.attrs["onclick"].split("\"")[1]
-                      if not soup.find("span",{"id": switchval + "_long"} ) : raise Exception("Generated html is invalid as could not find " + switchval + "_long")
-                      if not soup.find("span",{"id": switchval + "_short"} ) : raise Exception("Generated html is invalid as could not find " + switchval + "_short")
+    # Now run over all the inputs in the json
+    for item in tests["regtests"]:
+      with self.subTest(item=item):
+        print("INPUT", item["input"])
+        tokensource = list(PlumedLexer().get_tokens(item["input"]))
+        output = StringIO()
+        f.format(tokensource, output)
+        # Check for clickable labels
+        self.assertTrue(compare_to_reference(output.getvalue(), item))
+        soup = BeautifulSoup(output.getvalue(), "html.parser")
+        for val in soup.find_all("b"):
+          if "onclick" in val.attrs.keys():
+            vallabel = val.attrs["onclick"].split('"')[3]
+            self.assertTrue(soup.find("span", {"id": vallabel}))
+        # Check for switching cells
+        for val in soup.find_all(attrs={"class": "toggler"}):
+          if "onclick" in val.attrs.keys():
+            switchval = val.attrs["onclick"].split('"')[1]
+            if not soup.find("span", {"id": switchval + "_long"}):
+              raise Exception(
+                "Generated html is invalid as could not find " + switchval + "_long"
+              )
+            if not soup.find("span", {"id": switchval + "_short"}):
+              raise Exception(
+                "Generated html is invalid as could not find " + switchval + "_short"
+              )

--- a/tests/test_keyword_list.py
+++ b/tests/test_keyword_list.py
@@ -1,41 +1,67 @@
 from unittest import TestCase
 
-import os
-import json
 import PlumedToHTML
 
+
 class TestPlumedArguments(TestCase):
-   def testReadKeywords(self) : 
-       inpt = """
+  def testReadKeywords(self):
+    inpt = """
 ```plumed
 d1: DISTANCE ATOMS=1,2 
 PRINT ARG=d1 FILE=colvar
 ```
 """
-       actions = set({})
-       keyset = set({"ATOMS","COMPONENTS"})
-       with open("check_keywords_file", "w") as ofile :
-           PlumedToHTML.processMarkdownString( inpt, "check_keyword", ("plumed",), ("master",), actions, ofile, checkaction="DISTANCE", checkactionkeywords=keyset )
-       self.assertTrue( keyset==set({"COMPONENTS"}) )
-       
-       keyset = set({"ARG","FILE"})
-       with open("check_keywords_file", "w") as ofile :
-           PlumedToHTML.processMarkdownString( inpt, "check_keyword", ("plumed",), ("master",), actions, ofile, checkaction="PRINT", checkactionkeywords=keyset )
-       self.assertTrue( len(keyset)==0 )
+    actions = set({})
+    keyset = set({"ATOMS", "COMPONENTS"})
+    with open("check_keywords_file", "w") as ofile:
+      PlumedToHTML.processMarkdownString(
+        inpt,
+        "check_keyword",
+        ("plumed",),
+        ("master",),
+        actions,
+        ofile,
+        checkaction="DISTANCE",
+        checkactionkeywords=keyset,
+      )
+    self.assertTrue(keyset == set({"COMPONENTS"}))
 
-       inpt = """
+    keyset = set({"ARG", "FILE"})
+    with open("check_keywords_file", "w") as ofile:
+      PlumedToHTML.processMarkdownString(
+        inpt,
+        "check_keyword",
+        ("plumed",),
+        ("master",),
+        actions,
+        ofile,
+        checkaction="PRINT",
+        checkactionkeywords=keyset,
+      )
+    self.assertTrue(len(keyset) == 0)
+
+    inpt = """
 ```plumed
 d1: DISTANCE ATOMS1=1,2 ATOMS2=3,4 
 PRINT ARG=d1 FILE=colvar
 ```
 """
-       actions = set({})
-       keyset = set({"ATOMS","COMPONENTS"})
-       with open("check_keywords_file", "w") as ofile :
-           PlumedToHTML.processMarkdownString( inpt, "check_keyword", ("plumed",), ("master",), actions, ofile, checkaction="DISTANCE", checkactionkeywords=keyset )
-       self.assertTrue( keyset==set({"COMPONENTS"}) )
+    actions = set({})
+    keyset = set({"ATOMS", "COMPONENTS"})
+    with open("check_keywords_file", "w") as ofile:
+      PlumedToHTML.processMarkdownString(
+        inpt,
+        "check_keyword",
+        ("plumed",),
+        ("master",),
+        actions,
+        ofile,
+        checkaction="DISTANCE",
+        checkactionkeywords=keyset,
+      )
+    self.assertTrue(keyset == set({"COMPONENTS"}))
 
-       inpt = """
+    inpt = """
 ```plumed
 # Define two groups of atoms
 g: GROUP ATOMS=1-5
@@ -63,9 +89,18 @@ m: CONCATENATE ...
 ```
 """
 
-       actions = set({})
-       keyset = set({"MATRIX"})
-       with open("check_keywords_file", "w") as ofile :
-           PlumedToHTML.processMarkdownString( inpt, "check_keyword", ("plumed",), ("master",), actions, ofile, checkaction="CONCATENATE", checkactionkeywords=keyset )
-       print( "final keyset", keyset )
-       self.assertTrue( keyset==set({}) )     
+    actions = set({})
+    keyset = set({"MATRIX"})
+    with open("check_keywords_file", "w") as ofile:
+      PlumedToHTML.processMarkdownString(
+        inpt,
+        "check_keyword",
+        ("plumed",),
+        ("master",),
+        actions,
+        ofile,
+        checkaction="CONCATENATE",
+        checkactionkeywords=keyset,
+      )
+    print("final keyset", keyset)
+    self.assertTrue(keyset == set({}))

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,29 +1,29 @@
 from unittest import TestCase
 
-import os
 import json
 from io import StringIO
 from PlumedToHTML.PlumedLexer import PlumedLexer
 from pygments.formatters import HtmlFormatter
 
+
 class TestPlumedLexer(TestCase):
-   def testSimple(self) :
-       # Open the json file and read it in
-       f = open("tdata/lexertests.json")
-       tests = json.load(f)
-       f.close()
+  def testSimple(self):
+    # Open the json file and read it in
+    f = open("tdata/lexertests.json")
+    tests = json.load(f)
+    f.close()
 
-       # Setup an HTML formatter
-       f = HtmlFormatter()  
+    # Setup an HTML formatter
+    f = HtmlFormatter()
 
-       # Now run over all the inputs in the json
-       for item in tests["regtests"] :
-           with self.subTest(item=item):
-               tokensource = list(PlumedLexer().get_tokens(item["input"]))
-               output = StringIO()
-               f.format( tokensource, output )
-               data = {}
-               data["out"] = output.getvalue() 
-               print( item["input"] )
-               print( json.dumps( data, indent=3 ) )
-               self.assertTrue( output.getvalue()==item["output"] )
+    # Now run over all the inputs in the json
+    for item in tests["regtests"]:
+      with self.subTest(item=item):
+        tokensource = list(PlumedLexer().get_tokens(item["input"]))
+        output = StringIO()
+        f.format(tokensource, output)
+        data = {}
+        data["out"] = output.getvalue()
+        print(item["input"])
+        print(json.dumps(data, indent=3))
+        self.assertTrue(output.getvalue() == item["output"])

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -5,78 +5,95 @@ import json
 import PlumedToHTML
 from bs4 import BeautifulSoup
 
+
 class TestPlumedToHTML(TestCase):
-   def testBasicOutput(self) :
-       # Open the json file and read it in
-       f = open("tdata/tests.json")
-       tests = json.load(f)
-       f.close()
+  def testBasicOutput(self):
+    # Open the json file and read it in
+    f = open("tdata/tests.json")
+    tests = json.load(f)
+    f.close()
 
-       # Now run over all the inputs in the json
-       n=1
-       for item in tests["regtests"] :
-           with self.subTest(item=item):
-                print("INPUT", item["index"], item["input"] )
-                if "__FILL__" in item["input"] : continue
-                with open("testmarkdown" + str(n) +".md", "w") as of :
-                     of.write("# TEST MARKDOWN \n\n")
-                     of.write("Some text before DISTANCE \n")
-                     of.write("```plumed`\n")
-                     of.write( item["input"] + "\n")
-                     of.write("```\n")
-                     of.write("Some text after \n")
-                actions = set()
-                PlumedToHTML.processMarkdown( "testmarkdown" + str(n) +".md", ("plumed",), ("master",), actions )
-                self.assertTrue( actions==set(item["actions"]) ) 
-                with open("testmarkdown" + str(n) +".md", "r") as f : inp = f.read()
-                out, inhtml = "", False
-                for line in inp.splitlines() :
-                    if inhtml and "{% endraw %}" in line : inhtml = False
-                    elif inhtml : out += line + "\n"
-                    elif "{% raw %}" in line : inhtml = True 
-                self.assertTrue( PlumedToHTML.compare_to_reference( out, item ) )
-                soup = BeautifulSoup( out, "html.parser" )
-                # Check the badges 
-                out_badges = soup.find_all("img")
-                self.assertTrue( len(out_badges)==len(item["badges"]) )
-                for i in range(len(out_badges)) :
-                    if item["badges"][i]=="pass" : self.assertTrue( out_badges[i].attrs["src"].find("passing")>0 ) 
-                    elif item["badges"][i]=="fail" : self.assertTrue( out_badges[i].attrs["src"].find("failed")>0 )
-                    elif item["badges"][i]=="load" : self.assertTrue( out_badges[i].attrs["src"].find("with-LOAD")>0 )
-                    elif item["badges"][i]=="incomplete" : self.assertTrue( out_badges[i].attrs["src"].find("incomplete")>0 )
-                n=n+1
+    # Now run over all the inputs in the json
+    n = 1
+    for item in tests["regtests"]:
+      with self.subTest(item=item):
+        print("INPUT", item["index"], item["input"])
+        if "__FILL__" in item["input"]:
+          continue
+        with open("testmarkdown" + str(n) + ".md", "w") as of:
+          of.write("# TEST MARKDOWN \n\n")
+          of.write("Some text before DISTANCE \n")
+          of.write("```plumed`\n")
+          of.write(item["input"] + "\n")
+          of.write("```\n")
+          of.write("Some text after \n")
+        actions = set()
+        PlumedToHTML.processMarkdown(
+          "testmarkdown" + str(n) + ".md", ("plumed",), ("master",), actions
+        )
+        self.assertTrue(actions == set(item["actions"]))
+        with open("testmarkdown" + str(n) + ".md", "r") as f:
+          inp = f.read()
+        out, inhtml = "", False
+        for line in inp.splitlines():
+          if inhtml and "{% endraw %}" in line:
+            inhtml = False
+          elif inhtml:
+            out += line + "\n"
+          elif "{% raw %}" in line:
+            inhtml = True
+        self.assertTrue(PlumedToHTML.compare_to_reference(out, item))
+        soup = BeautifulSoup(out, "html.parser")
+        # Check the badges
+        out_badges = soup.find_all("img")
+        self.assertTrue(len(out_badges) == len(item["badges"]))
+        for i in range(len(out_badges)):
+          if item["badges"][i] == "pass":
+            self.assertTrue(out_badges[i].attrs["src"].find("passing") > 0)
+          elif item["badges"][i] == "fail":
+            self.assertTrue(out_badges[i].attrs["src"].find("failed") > 0)
+          elif item["badges"][i] == "load":
+            self.assertTrue(out_badges[i].attrs["src"].find("with-LOAD") > 0)
+          elif item["badges"][i] == "incomplete":
+            self.assertTrue(out_badges[i].attrs["src"].find("incomplete") > 0)
+        n = n + 1
 
-       with open("testmarkdown" + str(n) +".md", "w") as of :
-            of.write("# TEST MARKDOWN \n\n")
-            of.write("Some text before \n")
-            of.write("```plumed`\n")
-            of.write("#SOLUTIONFILE=tdata/solution.dat\n")
-            of.write("d: DISTANCE __FILL__=1,2\n")
-            of.write("```\n")
-            of.write("Some text after \n")
-       actions = set() 
-       PlumedToHTML.processMarkdown( "testmarkdown" + str(n) +".md", ("plumed",), ("master",), actions )
-       self.assertTrue( actions==set(["DISTANCE"]) )
+    with open("testmarkdown" + str(n) + ".md", "w") as of:
+      of.write("# TEST MARKDOWN \n\n")
+      of.write("Some text before \n")
+      of.write("```plumed`\n")
+      of.write("#SOLUTIONFILE=tdata/solution.dat\n")
+      of.write("d: DISTANCE __FILL__=1,2\n")
+      of.write("```\n")
+      of.write("Some text after \n")
+    actions = set()
+    PlumedToHTML.processMarkdown(
+      "testmarkdown" + str(n) + ".md", ("plumed",), ("master",), actions
+    )
+    self.assertTrue(actions == set(["DISTANCE"]))
 
+  def testHeader(self):
+    # checks that the header has been installed
+    # assuming that we are in /tests
+    headerfilename = os.path.join(
+      os.path.dirname(__file__), "../src/PlumedToHTML/assets/header.html"
+    )
+    hfile = open(headerfilename)
+    codes = hfile.read()
+    hfile.close()
+    self.assertTrue(codes == PlumedToHTML.get_html_header())
 
-   def testHeader(self) :
-       #checks that the header has been installed
-       #assuming that we are in /tests
-       headerfilename = os.path.join(os.path.dirname(__file__),"../src/PlumedToHTML/assets/header.html")
-       hfile = open( headerfilename )
-       codes = hfile.read()
-       hfile.close()
-       self.assertTrue( codes==PlumedToHTML.get_html_header() )
-
-   def testJavascriptAndCSS(self) : 
-       headerfilename = os.path.join(os.path.dirname(__file__),"../src/PlumedToHTML/assets/header.html")
-       hfile = open( headerfilename )
-       codes = hfile.read()
-       hfile.close()
-       reference = "<style>\n"
-       reference += PlumedToHTML.get_css()
-       reference += "</style>\n<script>\n"
-       reference += PlumedToHTML.get_javascript()
-       reference += "</script>\n"
-       print( reference )
-       self.assertTrue( codes==reference )
+  def testJavascriptAndCSS(self):
+    headerfilename = os.path.join(
+      os.path.dirname(__file__), "../src/PlumedToHTML/assets/header.html"
+    )
+    hfile = open(headerfilename)
+    codes = hfile.read()
+    hfile.close()
+    reference = "<style>\n"
+    reference += PlumedToHTML.get_css()
+    reference += "</style>\n<script>\n"
+    reference += PlumedToHTML.get_javascript()
+    reference += "</script>\n"
+    print(reference)
+    self.assertTrue(codes == reference)

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -4,36 +4,49 @@ import os
 import subprocess
 from PlumedToHTML import get_mermaid
 
+
 class TestPlumedToHTMLMermaid(TestCase):
-   def testNormalGraph(self) :
-       inpt="d1: DISTANCE ATOMS=1,2\n PRINT ARG=d1 FILE=colvar"
-       mermaid_this = get_mermaid( "plumed", inpt, False )
-       iff = open("test_mermaid.dat","w+")
-       iff.write(inpt)
-       iff.close()
-       cmd = ['plumed', 'show_graph', '--plumed', 'test_mermaid.dat', '--out', 'test_mermaid.md']
-       plumed_out = subprocess.run(cmd, capture_output=True, text=True )
-       mf = open("test_mermaid.md")
-       mermaid_pp = mf.read()
-       mf.close()
-       os.remove("test_mermaid.dat")
-       os.remove("test_mermaid.md")
-       self.assertTrue( mermaid_pp == mermaid_this )
+  def testNormalGraph(self):
+    inpt = "d1: DISTANCE ATOMS=1,2\n PRINT ARG=d1 FILE=colvar"
+    mermaid_this = get_mermaid("plumed", inpt, False)
+    iff = open("test_mermaid.dat", "w+")
+    iff.write(inpt)
+    iff.close()
+    cmd = [
+      "plumed",
+      "show_graph",
+      "--plumed",
+      "test_mermaid.dat",
+      "--out",
+      "test_mermaid.md",
+    ]
+    _ = subprocess.run(cmd, capture_output=True, text=True)
+    mf = open("test_mermaid.md")
+    mermaid_pp = mf.read()
+    mf.close()
+    os.remove("test_mermaid.dat")
+    os.remove("test_mermaid.md")
+    self.assertTrue(mermaid_pp == mermaid_this)
 
-   def testForceGraph(self) :
-       inpt="d1: DISTANCE ATOMS=1,2\n rr: RESTRAINT ARG=d1 KAPPA=10 AT=1"
-       mermaid_this = get_mermaid( "plumed", inpt, True )
-       iff = open("test_mermaid.dat","w+")
-       iff.write(inpt)
-       iff.close()
-       cmd = ['plumed', 'show_graph', '--plumed', 'test_mermaid.dat', '--out', 'test_mermaid.md', '--force']
-       plumed_out = subprocess.run(cmd, capture_output=True, text=True )
-       mf = open("test_mermaid.md")
-       mermaid_pp = mf.read()
-       mf.close()
-       os.remove("test_mermaid.dat")
-       os.remove("test_mermaid.md")
-       self.assertTrue( mermaid_pp == mermaid_this )
-       
-
-
+  def testForceGraph(self):
+    inpt = "d1: DISTANCE ATOMS=1,2\n rr: RESTRAINT ARG=d1 KAPPA=10 AT=1"
+    mermaid_this = get_mermaid("plumed", inpt, True)
+    iff = open("test_mermaid.dat", "w+")
+    iff.write(inpt)
+    iff.close()
+    cmd = [
+      "plumed",
+      "show_graph",
+      "--plumed",
+      "test_mermaid.dat",
+      "--out",
+      "test_mermaid.md",
+      "--force",
+    ]
+    _ = subprocess.run(cmd, capture_output=True, text=True)
+    mf = open("test_mermaid.md")
+    mermaid_pp = mf.read()
+    mf.close()
+    os.remove("test_mermaid.dat")
+    os.remove("test_mermaid.md")
+    self.assertTrue(mermaid_pp == mermaid_this)


### PR DESCRIPTION
Hi @gtribello, look if you like this:

I added a formatter and a static check that helps in looking for errors (such as unused variables/imports, wrong variables hidden in raised exceptions, it seems to dislike using 'l' as variable since it is similar to 'I', and so on)
This should help in tracking future merges/changes like we do with astyle and codecheck in plumed

I chose to use and indent of 2 spaces, but this is an opinionated choice of mine, I can change it

To format things on your pc you simply need to run `tox` in the home directory of the project:
it will
- format
- check for some python errors
- run the test locally
in this order

to run the check alone you can run `ruff format` (or `tox -e format`), `ruff check` (or `tox -e linting`)

The CI will softly enforce the check and the formatting, but with no interference in the the old tests